### PR TITLE
Add release for basic auth

### DIFF
--- a/.github/workflows/release-basic-auth.yml
+++ b/.github/workflows/release-basic-auth.yml
@@ -1,8 +1,12 @@
 name: Publish to NPM
 
+env:
+  package: basic-auth
+
 on:
   release:
-    types: [published]
+    tags:
+      - '$package-*' # Push events to matching basic-auth-*, i.e. basic-auth-1.12.6
 
 jobs:
   build-and-publish:
@@ -19,7 +23,7 @@ jobs:
     - run: npm ci
     - run: git config --global user.name "Automated NPM Release"
     - run: git config --global user.email "sysadmin+npm-deploy@aligent.com.au"
-    - run: npm version ${{ github.event.release.tag_name }} --allow-same-version
+    - run: npm version ${{ github.event.release.tag_name }#"$package-"}} --allow-same-version # strip the package out of the release name
     - run: npm run build
     - run: npm test
     - run: npm publish --access public


### PR DESCRIPTION
Can't test the GitHub release locally so am merging this in to test. I will add the other ones assuming this release works.

As we spoke about in guild there will be one release pipe for each package. I've tried to make it as copy paste friendly as possible by using a package variable. 