### PR TITLE
Add ListTags permission

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -138,7 +138,8 @@ export class ServiceDeployIAM extends cdk.Stack {
                          "lambda:GetFunctionConfiguration",
                          "lambda:AddPermission",
                          "lambda:RemovePermission",
-                         "lambda:InvokeFunction"
+                         "lambda:InvokeFunction",
+                         "lambda:ListTags"
                     ]
                })
           );


### PR DESCRIPTION
Got a recent error in a pipeline. It looks like serverless might require the `lambda:ListTags` permission now. 

`DO-1323: Code Review`