### PR TITLE
include missing lambda:ListTags

### DIFF
--- a/packages/serverless-deploy-iam/bin/app.ts
+++ b/packages/serverless-deploy-iam/bin/app.ts
@@ -138,7 +138,8 @@ export class ServiceDeployIAM extends cdk.Stack {
                          "lambda:GetFunctionConfiguration",
                          "lambda:AddPermission",
                          "lambda:RemovePermission",
-                         "lambda:InvokeFunction"
+                         "lambda:InvokeFunction",
+                         "lambda:ListTags"
                     ]
                })
           );


### PR DESCRIPTION
`lambda:ListTags` This will allow lambda to list function tags. 
for docs: [see](https://docs.aws.amazon.com/lambda/latest/dg/API_ListTags.html)