### PR TITLE
DO-1285: Added the Export names for cfnOutput

### DIFF
--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -42,7 +42,7 @@ export class StaticHosting extends Construct {
     constructor(scope: Construct, id: string, props: StaticHostingProps) {
         super(scope, id);
         
-        // Should the stackExportPrefix is empty it should StaticHosting as the prefix
+        // Should the stackExportPrefix is empty, 'StaticHosting' should be used as the prefix 
         const exportPrefix =  props.stackExportPrefix ? props.stackExportPrefix :  'StaticHosting'
 
         const siteName = `${props.subDomainName}.${props.domainName}`;

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -7,6 +7,7 @@ import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 import { User, Group, Policy, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 
 export interface StaticHostingProps {
+    stackExportPrefix?: string, 
     domainName: string;
     subDomainName: string;
     certificateArn: string;
@@ -30,7 +31,7 @@ export interface StaticHostingProps {
     prependCustomOriginBehaviours?: boolean;
 
     /**
-     * Optional set of behaviors to override the default behvior defined in this construct
+     * Optional set of behaviors to override the default behavior defined in this construct
      */
     behaviors?: Array<Behavior>;
     enableErrorConfig: boolean;
@@ -40,6 +41,9 @@ export interface StaticHostingProps {
 export class StaticHosting extends Construct {
     constructor(scope: Construct, id: string, props: StaticHostingProps) {
         super(scope, id);
+        
+        // Should the stackExportPrefix is empty it should StaticHosting as the prefix
+        const exportPrefix =  props.stackExportPrefix ? props.stackExportPrefix :  'StaticHosting'
 
         const siteName = `${props.subDomainName}.${props.domainName}`;
         const siteNameArray: Array<string> = [siteName];
@@ -63,6 +67,7 @@ export class StaticHosting extends Construct {
             new CfnOutput(this, 'S3LoggingBucketName', {
                 description: "S3 Logs",
                 value: s3LoggingBucket.bucketName,
+                exportName: `${exportPrefix}S3LoggingBucketName` 
             });
         }
 
@@ -77,6 +82,7 @@ export class StaticHosting extends Construct {
         new CfnOutput(this, 'Bucket', {
             description: 'BucketName',
             value: bucket.bucketName,
+            exportName: `${exportPrefix}BucketName`
         });
 
         const oai = new OriginAccessIdentity(this, 'OriginAccessIdentity', {
@@ -95,6 +101,7 @@ export class StaticHosting extends Construct {
             new CfnOutput(this, 'PublisherUserName', {
                 description: 'PublisherUser',
                 value: publisherUser.userName,
+                exportName: `${exportPrefix}PublisherUser`
             });
         };
 
@@ -108,6 +115,7 @@ export class StaticHosting extends Construct {
             new CfnOutput(this, 'PublisherGroupName', {
                 description: 'PublisherGroup',
                 value: publisherGroup.groupName,
+                exportName: `${exportPrefix}PublisherGroup`
             });
 
             if (publisherUser) {
@@ -131,6 +139,7 @@ export class StaticHosting extends Construct {
             new CfnOutput(this, 'LoggingBucketName', {
                 description: "CloudFront Logs",
                 value: loggingBucket.bucketName,
+                exportName: `${exportPrefix}LoggingBucketName`
             });
         }
 
@@ -208,10 +217,12 @@ export class StaticHosting extends Construct {
         new CfnOutput(this, 'DistributionId', {
             description: 'DistributionId',
             value: distribution.distributionId,
+            exportName: `${exportPrefix}DistributionID`
         });
         new CfnOutput(this, 'DistributionDomainName', {
             description: 'DistributionDomainName',
             value: distribution.distributionDomainName,
+            exportName: `${exportPrefix}DistributionName`
         });
 
         if (props.createDnsRecord && props.zoneName) {

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -7,7 +7,7 @@ import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 import { User, Group, Policy, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 
 export interface StaticHostingProps {
-    stackExportPrefix?: string, 
+    exportPrefix?: string, 
     domainName: string;
     subDomainName: string;
     certificateArn: string;
@@ -43,7 +43,7 @@ export class StaticHosting extends Construct {
         super(scope, id);
         
         // Should the stackExportPrefix is empty, 'StaticHosting' should be used as the prefix 
-        const exportPrefix =  props.stackExportPrefix ? props.stackExportPrefix :  'StaticHosting'
+        const exportPrefix =  props.exportPrefix ? props.exportPrefix :  'StaticHosting'
 
         const siteName = `${props.subDomainName}.${props.domainName}`;
         const siteNameArray: Array<string> = [siteName];


### PR DESCRIPTION
Introduced a parameter call `stackExportPrefix` and enable export name in CloudFormation output.