### PR TITLE
Feature/do 1285 monorepo workflow configs

### DIFF
--- a/packages/basic-auth/package.json
+++ b/packages/basic-auth/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "description": "A Cloudfront Lambda@Edge stack for performing basic auth protection",
   "main": "index.js",
-  "private": true,
   "scripts": {
     "build": "tsc && cd ./lib/handlers && npm ci",
     "prepublish": "tsc && cd ./lib/handlers && npm ci"

--- a/packages/basic-auth/tsconfig.json
+++ b/packages/basic-auth/tsconfig.json
@@ -1,30 +1,6 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
-    "module": "commonjs",
-    "lib": ["es2018"],
-    "declaration": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
-    "inlineSourceMap": true,
-    "inlineSources": true,
-    "experimentalDecorators": true,
-    "strictPropertyInitialization": false,
-    "typeRoots": ["./node_modules/@types"],
-    "types": [
-      "node",
-      "jest"
-    ]
-  },
-  "exclude": [
-    "cdk.out",
-    "lib/handlers/**"
-  ]
+    "outDir": "lib"
+  }
 }

--- a/packages/cloudfront-security-headers/tsconfig.json
+++ b/packages/cloudfront-security-headers/tsconfig.json
@@ -1,31 +1,6 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
-    "module": "commonjs",
-    "lib": [
-      "es2018"
-    ],
-    "declaration": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
-    "inlineSourceMap": true,
-    "inlineSources": true,
-    "experimentalDecorators": true,
-    "strictPropertyInitialization": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ]
-  },
-  "exclude": [
-    "node_modules",
-    "cdk.out",
-    "lib/handlers/**"
-  ]
+    "outDir": "lib"
+  }
 }

--- a/packages/geoip-redirect/package.json
+++ b/packages/geoip-redirect/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@aligent/cdk-geoip-redirect",
   "version": "0.1.0",
-  "private": true,
   "description": "A Cloudfront Lambda@Edge stack for performing redirection based on CloudFront-Viewer-Country",
   "main": "index.js",
   "scripts": {

--- a/packages/geoip-redirect/tsconfig.json
+++ b/packages/geoip-redirect/tsconfig.json
@@ -1,26 +1,6 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
-    "module": "commonjs",
-    "lib": ["es2018"],
-    "declaration": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
-    "inlineSourceMap": true,
-    "inlineSources": true,
-    "experimentalDecorators": true,
-    "strictPropertyInitialization": false,
-    "typeRoots": ["./node_modules/@types"]
-  },
-  "exclude": [
-    "cdk.out",
-    "lib/handlers/**"
-  ]
+    "outDir": "lib"
+  }
 }

--- a/packages/prerender-proxy/tsconfig.json
+++ b/packages/prerender-proxy/tsconfig.json
@@ -1,26 +1,6 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
-    "module": "commonjs",
-    "lib": ["es2018"],
-    "declaration": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
-    "inlineSourceMap": true,
-    "inlineSources": true,
-    "experimentalDecorators": true,
-    "strictPropertyInitialization": false,
-    "typeRoots": ["./node_modules/@types"]
-  },
-  "exclude": [
-    "cdk.out",
-    "lib/handlers/**"
-  ]
+    "outDir": "lib"
+  }
 }

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@aligent/cdk-rabbitmq",
   "version": "0.1.0",
-  "private": true,
   "main": "index.js",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/aligent/aws-rabbitmq-waf-stack#readme",

--- a/packages/rabbitmq/tsconfig.json
+++ b/packages/rabbitmq/tsconfig.json
@@ -1,23 +1,6 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2018",
-    "module": "commonjs",
-    "lib": ["es2018"],
-    "declaration": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": false,
-    "inlineSourceMap": true,
-    "inlineSources": true,
-    "experimentalDecorators": true,
-    "strictPropertyInitialization": false,
-    "typeRoots": ["./node_modules/@types"]
-  },
-  "exclude": ["cdk.out"]
+    "outDir": "lib"
+  }
 }

--- a/packages/static-hosting/package.json
+++ b/packages/static-hosting/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@aligent/cdk-static-hosting",
   "version": "0.1.5",
-  "private": true,
   "main": "index.ts",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/aligent/aws-cdk-static-hosting-stack#readme",


### PR DESCRIPTION
In this PR

- It has been found that when publishing packages, `private: true`, make them skip.
- Update the `tsconfig.json` to follow monorepo approach.