### PR TITLE
Add js files to non-ignore list for npm

### DIFF
--- a/packages/basic-auth/.npmignore
+++ b/packages/basic-auth/.npmignore
@@ -1,6 +1,7 @@
 *.ts
 !lib/handlers/*.ts
 !*.d.ts
+!*.js
 
 # CDK asset staging directory
 .cdk.staging

--- a/packages/cloudfront-security-headers/.npmignore
+++ b/packages/cloudfront-security-headers/.npmignore
@@ -1,7 +1,11 @@
 *.ts
 !lib/handlers/*.ts
 !*.d.ts
+!*.js
 
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+# Samples
+sample/

--- a/packages/geoip-redirect/.npmignore
+++ b/packages/geoip-redirect/.npmignore
@@ -1,6 +1,7 @@
 *.ts
 !lib/handlers/*.ts
 !*.d.ts
+!*.js
 
 # CDK asset staging directory
 .cdk.staging

--- a/packages/prerender-proxy-internal/.npmignore
+++ b/packages/prerender-proxy-internal/.npmignore
@@ -1,6 +1,7 @@
 *.ts
 !lib/handlers/*.ts
 !*.d.ts
+!*.js
 
 # CDK asset staging directory
 .cdk.staging

--- a/packages/prerender-proxy/.npmignore
+++ b/packages/prerender-proxy/.npmignore
@@ -1,6 +1,7 @@
 *.ts
 !lib/handlers/*.ts
 !*.d.ts
+!*.js
 
 # CDK asset staging directory
 .cdk.staging

--- a/packages/rabbitmq/.npmignore
+++ b/packages/rabbitmq/.npmignore
@@ -1,6 +1,11 @@
 *.ts
+!lib/handlers/*.ts
 !*.d.ts
+!*.js
 
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+# Samples
+sample/

--- a/packages/static-hosting/.npmignore
+++ b/packages/static-hosting/.npmignore
@@ -1,5 +1,7 @@
 *.ts
+!lib/handlers/*.ts
 !*.d.ts
+!*.js
 
 # CDK asset staging directory
 .cdk.staging

--- a/packages/waf/.npmignore
+++ b/packages/waf/.npmignore
@@ -1,5 +1,7 @@
 *.ts
+!lib/handlers/*.ts
 !*.d.ts
+!*.js
 
 # CDK asset staging directory
 .cdk.staging


### PR DESCRIPTION
Not sure exactly what changed here as the old configuration worked fine here: https://github.com/aligent/cdk-prerender-proxy/blob/main/.npmignore

Tested this locally and it includes the required `js` files that the package was missing.
![image](https://user-images.githubusercontent.com/6127662/179643415-e9a0ce17-ab7b-482e-8e94-271c64e92fb4.png)
Without this the included files were:
![image](https://user-images.githubusercontent.com/6127662/179643456-a324cb62-dd8b-4aae-89fc-8964d20b532d.png)

Which would then cause this error when using the published package:
![image](https://user-images.githubusercontent.com/6127662/179643531-4e33f258-69d5-417c-97ed-3918ce019097.png)

Theoretically, when we publish to npm now these `js` files will be included and we won't run into this error anymore.

I think the reason this happens is because we exclude handlers in the package.json: `"lib/handlers/**"` but we allow ts files in the .npmignore `!lib/handlers/*.ts`.  