### PR TITLE
DO-1360: Change prerender fargate to use a token

### DIFF
--- a/packages/prerender-fargate/README.md
+++ b/packages/prerender-fargate/README.md
@@ -2,14 +2,14 @@
 A construct to host [Prerender](https://github.com/prerender/prerender) in Fargate. 
 
 ## Props
-`prerenderName`: Name of the Prerender service
-`domainName`: Domain name for Prerender
-`vpcId`: VPC to host Prerender in
-`bucketName`: Optional S3 bucket name
-`expirationDays`: Optional days until items expire in bucket (default to 7 days)
-`basicAuthList`: List of basic auth credentials to accept
-`certificateArn`: Certificate arn to match the domain
-`desiredInstanceCount`: Number of Prerender instances to run (default 1)
-`maxInstanceCount`: Maximum number of Prerender instances to run (default 2)
-`instanceCPU`: CPU to allocate to each instance (default 512)
-`instanceMemory`: Amount of memory to allocate to each instance (default 1024)
+ - `prerenderName`: Name of the Prerender service
+ - `domainName`: Domain name for Prerender
+ - `vpcId`: VPC to host Prerender in
+ - `bucketName`: Optional S3 bucket name
+ - `expirationDays`: Optional days until items expire in bucket (default to 7 days)
+ - `tokenList`: List of tokens to accept as authentication
+ - `certificateArn`: Certificate arn to match the domain
+ - `desiredInstanceCount`: Number of Prerender instances to run (default 1)
+ - `maxInstanceCount`: Maximum number of Prerender instances to run (default 2)
+ - `instanceCPU`: CPU to allocate to each instance (default 512)
+ - `instanceMemory`: Amount of memory to allocate to each instance (default 1024)

--- a/packages/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate.ts
@@ -16,7 +16,7 @@ export interface PrerenderOptions {
     vpcId: string,
     bucketName?: string,
     expirationDays?: number,
-    basicAuthList: Array<string[]>,
+    tokenList: Array<string>,
     certificateArn: string,
     desiredInstanceCount?: number,
     maxInstanceCount?: number,
@@ -77,7 +77,7 @@ export class PrerenderFargate extends Construct {
                         AWS_ACCESS_KEY_ID: accessKey.accessKeyId,
                         AWS_SECRET_ACCESS_KEY: accessKey.secretAccessKey.toString(),
                         AWS_REGION: Stack.of(this).region,
-                        BASIC_AUTH: props.basicAuthList.toString()
+                        TOKEN_LIST: props.tokenList.toString()
                     }
                 },
                 healthCheckGracePeriod: Duration.seconds(20),

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -19,12 +19,6 @@ server.use({
         let auth = req.headers['x-prerender-token'];
         if (!auth) return res.send(401);
 
-        // malformed
-        let parts = auth.split(' ');
-        if ('basic' != parts[0].toLowerCase()) return res.send(401);
-        if (!parts[1]) return res.send(401);
-        auth = parts[1].toString();
-
         // check credentials exist
         if (!auth) return res.send(401);
 

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -16,46 +16,28 @@ server.use(s3Cache);
 
 server.use({
     requestReceived: (req, res, next) => {
-        let auth = req.headers.x-prerender-authorization;
+        let auth = req.headers['x-prerender-token'];
         if (!auth) return res.send(401);
 
         // malformed
         let parts = auth.split(' ');
         if ('basic' != parts[0].toLowerCase()) return res.send(401);
         if (!parts[1]) return res.send(401);
-        auth = parts[1];
+        auth = parts[1].toString();
 
-        // credentials
-        auth = new Buffer.from(auth, 'base64').toString();
-        auth = auth.match(/^([^:]+):(.+)$/);
+        // check credentials exist
         if (!auth) return res.send(401);
 
         // compare credentials in header to list of allowed credentials
-        let basicAuthAllowList = [];
-
-        const basicAuthEnvList = process.env.BASIC_AUTH.toString().split(',');
-
-        for (const [index, element] of basicAuthEnvList.entries()) {
-            const authIndex = (index - index % 2) / 2
-            if (index % 2 === 0) {
-                basicAuthAllowList [authIndex] = [element];
-            } else {
-                basicAuthAllowList[authIndex].push(element)
-            }
-        }
+        const tokenAllowList = process.env.TOKEN_LIST.toString().split(',');
 
         let authenticated = false;
-        for (const basicAuth of basicAuthAllowList) {
-            authenticated = auth[1] === basicAuth[0] && auth[2] === basicAuth[1]
+        for (const token of tokenAllowList) {
+            authenticated = auth === token;
 
             if (authenticated) break;
         }
         if (!authenticated) return res.send(401);
-
-        req.prerender.authentication = {
-            name: auth[1],
-            password: auth[2]
-        };
 
         return next();
     }


### PR DESCRIPTION
This is part of the process to combine the prerender proxy functions into one. 

This replaces the previous basic auth method with a token method. This brings it inline with what prerender.io uses.