### PR TITLE
Remove package private option

### DIFF
--- a/packages/prerender-proxy/package.json
+++ b/packages/prerender-proxy/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@aligent/cdk-prerender-proxy",
   "version": "0.1.7",
-  "private": true,
   "description": "A Cloudfront Lambda@Edge stack for integrating with prerender.io",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Private needs to be disabled to publish a public npm package. Thought I already disabled this but apparently not :man_shrugging: 