### PR TITLE
DO-1285: cherry pick a hotfix for npm publish

### DIFF
--- a/packages/basic-auth/.npmignore
+++ b/packages/basic-auth/.npmignore
@@ -1,0 +1,11 @@
+*.ts
+!lib/handlers/*.ts
+!*.d.ts
+!*.js
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# Samples
+sample/

--- a/packages/cloudfront-security-headers/.npmignore
+++ b/packages/cloudfront-security-headers/.npmignore
@@ -1,0 +1,11 @@
+*.ts
+!lib/handlers/*.ts
+!*.d.ts
+!*.js
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# Samples
+sample/

--- a/packages/geoip-redirect/.npmignore
+++ b/packages/geoip-redirect/.npmignore
@@ -1,0 +1,11 @@
+*.ts
+!lib/handlers/*.ts
+!*.d.ts
+!*.js
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# Samples
+sample/

--- a/packages/rabbitmq/.npmignore
+++ b/packages/rabbitmq/.npmignore
@@ -1,0 +1,11 @@
+*.ts
+!lib/handlers/*.ts
+!*.d.ts
+!*.js
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# Samples
+sample/

--- a/packages/static-hosting/.npmignore
+++ b/packages/static-hosting/.npmignore
@@ -1,0 +1,11 @@
+*.ts
+!lib/handlers/*.ts
+!*.d.ts
+!*.js
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# Samples
+sample/

--- a/packages/waf/.npmignore
+++ b/packages/waf/.npmignore
@@ -1,0 +1,11 @@
+*.ts
+!lib/handlers/*.ts
+!*.d.ts
+!*.js
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# Samples
+sample/


### PR DESCRIPTION
To fix not including `.js` files when publishing the npm packages.
This fix has been already committed to the main branch :)  