### PR TITLE
Updated WAF Construct

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5839,28 +5839,10 @@
                 "constructs": "^3.3.69"
             }
         },
-        "node_modules/@aws-cdk/aws-wafv2": {
-            "version": "1.165.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-wafv2/-/aws-wafv2-1.165.0.tgz",
-            "integrity": "sha512-Ax/mGrYc9ttx2zDjkTxuTIVlR9d7VPAfQhZ79hx1y0V6NReHOtP/KgCNZMVEym5e96FEAIJ1r+wlZuzt5NAWYQ==",
-            "peer": true,
-            "dependencies": {
-                "@aws-cdk/core": "1.165.0",
-                "constructs": "^3.3.69"
-            },
-            "engines": {
-                "node": ">= 14.15.0"
-            },
-            "peerDependencies": {
-                "@aws-cdk/core": "1.165.0",
-                "constructs": "^3.3.69"
-            }
-        },
         "node_modules/@aws-cdk/cfnspec": {
             "version": "1.168.0",
             "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.168.0.tgz",
             "integrity": "sha512-OOwIS0/DNPsQJdgcgr1KBVRDCZD/oKteOS1ZYwwVqLhmHpX+wKRjNmWRVhPbzWha7r0ugfbuEqG9DXvJbYkLvQ==",
-            "dev": true,
             "dependencies": {
                 "fs-extra": "^9.1.0",
                 "md5": "^2.3.0"
@@ -5924,7 +5906,6 @@
             "version": "1.168.0",
             "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.168.0.tgz",
             "integrity": "sha512-sFfmJjB5vwiToXgUkEyme0TRuV70lOeW4a68uhovw56Fn2hCdijHlJLSshTNXk13Z/RXdLvI2UcIcZ1hABLKOQ==",
-            "dev": true,
             "dependencies": {
                 "@aws-cdk/cfnspec": "1.168.0",
                 "@types/node": "^10.17.60",
@@ -5941,8 +5922,7 @@
         "node_modules/@aws-cdk/cloudformation-diff/node_modules/@types/node": {
             "version": "10.17.60",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-            "dev": true
+            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         },
         "node_modules/@aws-cdk/core": {
             "version": "1.165.0",
@@ -7528,8 +7508,7 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/base": {
             "version": "0.11.2",
@@ -7565,7 +7544,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7676,7 +7654,6 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -7713,7 +7690,6 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -7856,7 +7832,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
             "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-            "dev": true,
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
@@ -7929,8 +7904,7 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "node_modules/constructs": {
             "version": "3.4.51",
@@ -8045,7 +8019,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8565,7 +8538,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -8626,8 +8598,7 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
@@ -8661,7 +8632,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
@@ -8703,7 +8673,6 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -8756,7 +8725,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8928,7 +8896,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -8937,8 +8904,7 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/is-accessor-descriptor": {
             "version": "1.0.0",
@@ -9934,7 +9900,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dev": true,
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -10079,7 +10044,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -10362,7 +10326,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -10423,7 +10386,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -10438,7 +10400,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -10450,7 +10411,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -10492,7 +10452,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -10501,7 +10460,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10726,7 +10684,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10742,8 +10699,7 @@
         "node_modules/require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-            "dev": true
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
         },
         "node_modules/resolve": {
             "version": "1.22.1",
@@ -11154,7 +11110,6 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -11162,8 +11117,7 @@
         "node_modules/set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-            "dev": true
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
         },
         "node_modules/set-value": {
             "version": "2.0.1",
@@ -11727,7 +11681,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -12210,8 +12163,6 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "optional": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -12341,8 +12292,7 @@
         "node_modules/which-module": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
-            "dev": true
+            "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q=="
         },
         "node_modules/word-wrap": {
             "version": "1.2.3",
@@ -12356,7 +12306,6 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
             "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -12369,8 +12318,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/write-file-atomic": {
             "version": "3.0.3",
@@ -12420,8 +12368,7 @@
         "node_modules/y18n": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-            "dev": true
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
         },
         "node_modules/yallist": {
             "version": "4.0.0",
@@ -12433,7 +12380,6 @@
             "version": "15.4.1",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
             "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-            "dev": true,
             "dependencies": {
                 "cliui": "^6.0.0",
                 "decamelize": "^1.2.0",
@@ -12464,7 +12410,6 @@
             "version": "18.1.3",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
             "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-            "dev": true,
             "dependencies": {
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
@@ -20085,6 +20030,10 @@
             "version": "0.1.3",
             "license": "GPL-3.0-only",
             "dependencies": {
+                "@aws-cdk/aws-ec2": "1.111.0",
+                "@aws-cdk/aws-wafv2": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "aws-cdk": "1.111.0",
                 "source-map-support": "^0.5.16"
             },
             "devDependencies": {
@@ -20098,10 +20047,479 @@
                 "typescript": "^4.4.3"
             },
             "peerDependencies": {
-                "@aws-cdk/aws-ec2": "^1.111.0",
-                "@aws-cdk/aws-wafv2": "^1.111.0",
-                "@aws-cdk/core": "^1.111.0",
-                "aws-cdk": "^1.111.0"
+                "@aws-cdk/aws-ec2": "1.111.0",
+                "@aws-cdk/aws-wafv2": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "aws-cdk": "1.111.0"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/assets": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.111.0.tgz",
+            "integrity": "sha512-O1jZ0cZNxqjSc0tknbecEZZYw5VJxFLsruQT8WguUR0cW2+B6ukdyZw6NBZxAMDrXavWDbqiR/1rdchvm5c+QQ==",
+            "dependencies": {
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/aws-cloudwatch": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.111.0.tgz",
+            "integrity": "sha512-VdJrl53JJKpvK3tPJOGW46rq4BkVci1UaR2scJYzrFEvlUpnTk4TRrGWUZQ3h/A6tgJnitfY4JMhvuwLWGKOuQ==",
+            "dependencies": {
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/aws-ec2": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.111.0.tgz",
+            "integrity": "sha512-fCB4WYPWJj7yAH5Q+0mSJRPE2zIIpCpf+14NhkyPdClrSyPrDuFWPoZDiBXm0ejY0shhmcLDLyt27zzzQ+MbaA==",
+            "dependencies": {
+                "@aws-cdk/aws-cloudwatch": "1.111.0",
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/aws-kms": "1.111.0",
+                "@aws-cdk/aws-logs": "1.111.0",
+                "@aws-cdk/aws-s3": "1.111.0",
+                "@aws-cdk/aws-s3-assets": "1.111.0",
+                "@aws-cdk/aws-ssm": "1.111.0",
+                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "@aws-cdk/region-info": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/aws-cloudwatch": "1.111.0",
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/aws-kms": "1.111.0",
+                "@aws-cdk/aws-logs": "1.111.0",
+                "@aws-cdk/aws-s3": "1.111.0",
+                "@aws-cdk/aws-s3-assets": "1.111.0",
+                "@aws-cdk/aws-ssm": "1.111.0",
+                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "@aws-cdk/region-info": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/aws-events": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.111.0.tgz",
+            "integrity": "sha512-oYQtwyAUQheDF4BL2t6V9uRRd+3aLTMje/Y744JoxELEHPkP1EiEutg3kI0TER/S1BZ/E35wVkj3tR420p3QJg==",
+            "dependencies": {
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/aws-iam": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.111.0.tgz",
+            "integrity": "sha512-ha0Lv0iudBeuzOlBP5eadoaVf4fASyLDmcBg99f7gHImITaS2T5JqEFY4YRUYjwoJtAUkHTVIcMF2KanWORaIw==",
+            "dependencies": {
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/region-info": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/region-info": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/aws-kms": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.111.0.tgz",
+            "integrity": "sha512-m5wu7jRXBHsaevjBrBEjOWmXr9JjyAQWE6m2ONeAw+oNhXt3WZkGzjwIdRbJwX4wOqFv6tjcCvjRzoiKYVEscQ==",
+            "dependencies": {
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/aws-logs": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.111.0.tgz",
+            "integrity": "sha512-GmVLxVU8axHGL5Yd/HlKz/1ViMNJfl+HC9VO0r132XUcVpSX94ergOJFkdM5oJnjJaLdvzW2ZGtgv0anuAa9mQ==",
+            "dependencies": {
+                "@aws-cdk/aws-cloudwatch": "1.111.0",
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/aws-kms": "1.111.0",
+                "@aws-cdk/aws-s3-assets": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/aws-cloudwatch": "1.111.0",
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/aws-kms": "1.111.0",
+                "@aws-cdk/aws-s3-assets": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/aws-s3": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.111.0.tgz",
+            "integrity": "sha512-xZiJv/RjN1Cv4dqt9TxNAzw3wxqpPfsV9TQ9EDqzWc9f7ESMUj34+r2DSGHimLIf8WFvy4rFAYXY7akP9v77jA==",
+            "dependencies": {
+                "@aws-cdk/aws-events": "1.111.0",
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/aws-kms": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/aws-events": "1.111.0",
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/aws-kms": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/aws-s3-assets": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.111.0.tgz",
+            "integrity": "sha512-viKjW0TE+k23HpddxHUO6j+rCQBKmUYuIqvyhYD8p8tnsgmwBNKlLexiDghkd24+RmkFQMhQmrQrT4niSJffEw==",
+            "dependencies": {
+                "@aws-cdk/assets": "1.111.0",
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/aws-kms": "1.111.0",
+                "@aws-cdk/aws-s3": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/assets": "1.111.0",
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/aws-kms": "1.111.0",
+                "@aws-cdk/aws-s3": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/aws-ssm": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.111.0.tgz",
+            "integrity": "sha512-/rBwM0j8n78Ih62nnJ2d86hoChWid6BN0qEKYiK/1RqrWyXWpNAVADW0rK1Ous8L0qC1rHOFTCoxDVuIM6+VdQ==",
+            "dependencies": {
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/aws-kms": "1.111.0",
+                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/aws-iam": "1.111.0",
+                "@aws-cdk/aws-kms": "1.111.0",
+                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/aws-wafv2": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-wafv2/-/aws-wafv2-1.111.0.tgz",
+            "integrity": "sha512-E0WbM5Hjbt6KtQEDjD70p67gpzm5eKnADlTT+khGEXptqAtcIIDEMqTpPKS2mmvoYX/MwMMv3THNAU9zgrRTbA==",
+            "dependencies": {
+                "@aws-cdk/core": "1.111.0",
+                "constructs": "^3.3.69"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/core": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/cloud-assembly-schema": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.111.0.tgz",
+            "integrity": "sha512-Ql59HF7PDLQJislHAVhTZE8JHUtb5zikCjHseOuvWh3c5f5jjJ4i7pq9N6wjfamjfC7JGQ7LmRSXP61NIc3aNQ==",
+            "bundleDependencies": [
+                "jsonschema",
+                "semver"
+            ],
+            "dependencies": {
+                "jsonschema": "^1.4.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+            "version": "1.4.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+            "version": "7.3.5",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "packages/waf/node_modules/@aws-cdk/core": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.111.0.tgz",
+            "integrity": "sha512-ptI43hFZ6yClzyBbCQh1LZgy3b8Z0ekkb6XYCf1BtmqmimvQJOyBc68nfn+NaO2uGDRMor2XhkN9qIRpInSR4w==",
+            "bundleDependencies": [
+                "fs-extra",
+                "minimatch",
+                "@balena/dockerignore",
+                "ignore"
+            ],
+            "dependencies": {
+                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "@aws-cdk/region-info": "1.111.0",
+                "@balena/dockerignore": "^1.0.2",
+                "constructs": "^3.3.69",
+                "fs-extra": "^9.1.0",
+                "ignore": "^5.1.8",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "@aws-cdk/region-info": "1.111.0",
+                "constructs": "^3.3.69"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/@balena/dockerignore": {
+            "version": "1.0.2",
+            "inBundle": true,
+            "license": "Apache-2.0"
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/at-least-node": {
+            "version": "1.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/concat-map": {
+            "version": "0.0.1",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/graceful-fs": {
+            "version": "4.2.6",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/ignore": {
+            "version": "5.1.8",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/minimatch": {
+            "version": "3.0.4",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/core/node_modules/universalify": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/cx-api": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.111.0.tgz",
+            "integrity": "sha512-dGYu+3LapX3Gv4+68kOIQ2igIbAGCqNGcs5+8CFHqilBeRb31FyT5mU5yE3Hkp/+RW0Zy0T+MgCFcu0WXHgJBw==",
+            "bundleDependencies": [
+                "semver"
+            ],
+            "dependencies": {
+                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            },
+            "peerDependencies": {
+                "@aws-cdk/cloud-assembly-schema": "1.111.0"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/cx-api/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/cx-api/node_modules/semver": {
+            "version": "7.3.5",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/waf/node_modules/@aws-cdk/cx-api/node_modules/yallist": {
+            "version": "4.0.0",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "packages/waf/node_modules/@aws-cdk/region-info": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.111.0.tgz",
+            "integrity": "sha512-xUqNPkg5cEV/df1aSle2cc+yasgyOtFPMXw53PYMTArwfmHMsXb5Lna0lsFddMx4heO+be5XYUrWVijIiPHMIQ==",
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
             }
         },
         "packages/waf/node_modules/@types/jest": {
@@ -20127,6 +20545,1320 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk": {
+            "version": "1.111.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.111.0.tgz",
+            "integrity": "sha512-RUxaIDjJvCfUADVqAJtwJ3XUxWKPurjxbw8oIhannvGmM1w2fIgXSm8Jx1ZN91rYLiBfkLtQMaggwvPP7BH55g==",
+            "hasShrinkwrap": true,
+            "dependencies": {
+                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                "@aws-cdk/cloudformation-diff": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "@aws-cdk/region-info": "1.111.0",
+                "archiver": "^5.3.0",
+                "aws-sdk": "^2.848.0",
+                "camelcase": "^6.2.0",
+                "cdk-assets": "1.111.0",
+                "colors": "^1.4.0",
+                "decamelize": "^5.0.0",
+                "fs-extra": "^9.1.0",
+                "glob": "^7.1.7",
+                "json-diff": "^0.5.4",
+                "minimatch": ">=3.0",
+                "promptly": "^3.2.0",
+                "proxy-agent": "^4.0.1",
+                "semver": "^7.3.5",
+                "source-map-support": "^0.5.19",
+                "table": "^6.7.1",
+                "uuid": "^8.3.2",
+                "wrap-ansi": "^7.0.0",
+                "yaml": "1.10.2",
+                "yargs": "^16.2.0"
+            },
+            "bin": {
+                "cdk": "bin/cdk"
+            },
+            "engines": {
+                "node": ">= 10.13.0 <13 || >=13.7.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/@aws-cdk/cfnspec": {
+            "version": "1.111.0",
+            "dependencies": {
+                "md5": "^2.3.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/@aws-cdk/cloud-assembly-schema": {
+            "version": "1.111.0",
+            "dependencies": {
+                "jsonschema": "^1.4.0",
+                "semver": "^7.3.5"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/@aws-cdk/cloudformation-diff": {
+            "version": "1.111.0",
+            "dependencies": {
+                "@aws-cdk/cfnspec": "1.111.0",
+                "@types/node": "^10.17.60",
+                "colors": "^1.4.0",
+                "diff": "^5.0.0",
+                "fast-deep-equal": "^3.1.3",
+                "string-width": "^4.2.2",
+                "table": "^6.7.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/@aws-cdk/cx-api": {
+            "version": "1.111.0",
+            "dependencies": {
+                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                "semver": "^7.3.5"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/@aws-cdk/region-info": {
+            "version": "1.111.0"
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/@types/node": {
+            "version": "10.17.60",
+            "resolved": "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b",
+            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dependencies": {
+                "debug": "4"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ajv": {
+            "version": "8.6.0",
+            "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-8.6.0.tgz#60cc45d9c46a477d80d92c48076d972c342e5720",
+            "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/archiver": {
+            "version": "5.3.0",
+            "resolved": "https://registry.yarnpkg.com/archiver/-/archiver-5.3.0.tgz#dd3e097624481741df626267564f7dd8640a45ba",
+            "integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
+            "dependencies": {
+                "archiver-utils": "^2.1.0",
+                "async": "^3.2.0",
+                "buffer-crc32": "^0.2.1",
+                "readable-stream": "^3.6.0",
+                "readdir-glob": "^1.0.0",
+                "tar-stream": "^2.2.0",
+                "zip-stream": "^4.1.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/archiver-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2",
+            "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+            "dependencies": {
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.0",
+                "lazystream": "^1.0.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.union": "^4.6.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^2.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/archiver-utils/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ast-types": {
+            "version": "0.13.4",
+            "resolved": "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782",
+            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+            "dependencies": {
+                "tslib": "^2.0.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/async": {
+            "version": "3.2.0",
+            "resolved": "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720",
+            "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/aws-sdk": {
+            "version": "2.932.0",
+            "resolved": "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.932.0.tgz#43da32ab6de58a0eac6c7976feb6c9879fe09e7c",
+            "integrity": "sha512-U6MWUtFD0npWa+ReVEgm0fCIM0fMOYahFp14GLv8fC+BWOTvh5Iwt/gF8NrLomx42bBjA1Abaw6yhmiaSJDQHQ==",
+            "dependencies": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.15.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/aws-sdk/node_modules/buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "dependencies": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/aws-sdk/node_modules/buffer/node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/aws-sdk/node_modules/ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/aws-sdk/node_modules/uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/bytes": {
+            "version": "3.1.0",
+            "resolved": "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6",
+            "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/camelcase": {
+            "version": "6.2.0",
+            "resolved": "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809",
+            "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/cdk-assets": {
+            "version": "1.111.0",
+            "dependencies": {
+                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                "@aws-cdk/cx-api": "1.111.0",
+                "archiver": "^5.3.0",
+                "aws-sdk": "^2.848.0",
+                "glob": "^7.1.7",
+                "mime": "^2.5.2",
+                "yargs": "^16.2.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/charenc": {
+            "version": "0.0.2",
+            "resolved": "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667",
+            "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/cli-color": {
+            "version": "0.1.7",
+            "resolved": "https://registry.yarnpkg.com/cli-color/-/cli-color-0.1.7.tgz#adc3200fa471cc211b0da7f566b71e98b9d67347",
+            "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
+            "dependencies": {
+                "es5-ext": "0.8.x"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/colors": {
+            "version": "1.4.0",
+            "resolved": "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78",
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/compress-commons": {
+            "version": "4.1.1",
+            "resolved": "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.1.tgz#df2a09a7ed17447642bad10a85cc9a19e5c42a7d",
+            "integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+            "dependencies": {
+                "buffer-crc32": "^0.2.13",
+                "crc32-stream": "^4.0.2",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/crc-32": {
+            "version": "1.2.0",
+            "resolved": "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208",
+            "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+            "dependencies": {
+                "exit-on-epipe": "~1.0.1",
+                "printj": "~1.1.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/crc32-stream": {
+            "version": "4.0.2",
+            "resolved": "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-4.0.2.tgz#c922ad22b38395abe9d3870f02fa8134ed709007",
+            "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+            "dependencies": {
+                "crc-32": "^1.2.0",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/crypt": {
+            "version": "0.0.2",
+            "resolved": "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b",
+            "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/data-uri-to-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636",
+            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/debug": {
+            "version": "4.3.1",
+            "resolved": "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee",
+            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/decamelize": {
+            "version": "5.0.0",
+            "resolved": "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.0.tgz#88358157b010ef133febfd27c18994bd80c6215b",
+            "integrity": "sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/degenerator": {
+            "version": "2.2.0",
+            "resolved": "https://registry.yarnpkg.com/degenerator/-/degenerator-2.2.0.tgz#49e98c11fa0293c5b26edfbb52f15729afcdb254",
+            "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+            "dependencies": {
+                "ast-types": "^0.13.2",
+                "escodegen": "^1.8.1",
+                "esprima": "^4.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/diff": {
+            "version": "5.0.0",
+            "resolved": "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b",
+            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/difflib": {
+            "version": "0.2.4",
+            "resolved": "https://registry.yarnpkg.com/difflib/-/difflib-0.2.4.tgz#b5e30361a6db023176d562892db85940a718f47e",
+            "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
+            "dependencies": {
+                "heap": ">= 0.2.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/dreamopt": {
+            "version": "0.6.0",
+            "resolved": "https://registry.yarnpkg.com/dreamopt/-/dreamopt-0.6.0.tgz#d813ccdac8d39d8ad526775514a13dda664d6b4b",
+            "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
+            "dependencies": {
+                "wordwrap": ">=0.0.2"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/es5-ext": {
+            "version": "0.8.2",
+            "resolved": "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.8.2.tgz#aba8d9e1943a895ac96837a62a39b3f55ecd94ab",
+            "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/escodegen": {
+            "version": "1.14.3",
+            "resolved": "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503",
+            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/exit-on-epipe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692",
+            "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/file-uri-to-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba",
+            "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ftp": {
+            "version": "0.3.10",
+            "resolved": "https://registry.yarnpkg.com/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d",
+            "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+            "dependencies": {
+                "readable-stream": "1.1.x",
+                "xregexp": "2.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ftp/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ftp/node_modules/readable-stream": {
+            "version": "1.1.14",
+            "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9",
+            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ftp/node_modules/string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/get-uri": {
+            "version": "3.0.2",
+            "resolved": "https://registry.yarnpkg.com/get-uri/-/get-uri-3.0.2.tgz#f0ef1356faabc70e1f9404fa3b66b2ba9bfc725c",
+            "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "data-uri-to-buffer": "3",
+                "debug": "4",
+                "file-uri-to-path": "2",
+                "fs-extra": "^8.1.0",
+                "ftp": "^0.3.10"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/get-uri/node_modules/fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/get-uri/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/get-uri/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/glob": {
+            "version": "7.1.7",
+            "resolved": "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90",
+            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/graceful-fs": {
+            "version": "4.2.6",
+            "resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee",
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/heap": {
+            "version": "0.2.6",
+            "resolved": "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac",
+            "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/http-errors": {
+            "version": "1.7.3",
+            "resolved": "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06",
+            "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+            "dependencies": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/https-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2",
+            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ip": {
+            "version": "1.1.5",
+            "resolved": "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/jmespath": {
+            "version": "0.15.0",
+            "resolved": "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217",
+            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/json-diff": {
+            "version": "0.5.4",
+            "resolved": "https://registry.yarnpkg.com/json-diff/-/json-diff-0.5.4.tgz#7bc8198c441756632aab66c7d9189d365a7a035a",
+            "integrity": "sha512-q5Xmx9QXNOzOzIlMoYtLrLiu4Jl/Ce2bn0CNcv54PhyH89CI4GWlGVDye8ei2Ijt9R3U+vsWPsXpLUNob8bs8Q==",
+            "dependencies": {
+                "cli-color": "~0.1.6",
+                "difflib": "~0.2.1",
+                "dreamopt": "~0.6.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/jsonschema": {
+            "version": "1.4.0",
+            "resolved": "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2",
+            "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dependencies": {
+                "readable-stream": "^2.0.5"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/lazystream/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dependencies": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c",
+            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/lodash.difference": {
+            "version": "4.5.0",
+            "resolved": "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c",
+            "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/lodash.truncate": {
+            "version": "4.4.2",
+            "resolved": "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193",
+            "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/lodash.union": {
+            "version": "4.6.0",
+            "resolved": "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88",
+            "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/md5": {
+            "version": "2.3.0",
+            "resolved": "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f",
+            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+            "dependencies": {
+                "charenc": "0.0.2",
+                "crypt": "0.0.2",
+                "is-buffer": "~1.1.6"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/mime": {
+            "version": "2.5.2",
+            "resolved": "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe",
+            "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/mute-stream": {
+            "version": "0.0.8",
+            "resolved": "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d",
+            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/netmask": {
+            "version": "2.0.2",
+            "resolved": "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7",
+            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/optionator": {
+            "version": "0.8.3",
+            "resolved": "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495",
+            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+            "dependencies": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.6",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "word-wrap": "~1.2.3"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/pac-proxy-agent": {
+            "version": "4.1.0",
+            "resolved": "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz#66883eeabadc915fc5e95457324cb0f0ac78defb",
+            "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4",
+                "get-uri": "3",
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "5",
+                "pac-resolver": "^4.1.0",
+                "raw-body": "^2.2.0",
+                "socks-proxy-agent": "5"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/pac-resolver": {
+            "version": "4.2.0",
+            "resolved": "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-4.2.0.tgz#b82bcb9992d48166920bc83c7542abb454bd9bdd",
+            "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+            "dependencies": {
+                "degenerator": "^2.2.0",
+                "ip": "^1.1.5",
+                "netmask": "^2.0.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/printj": {
+            "version": "1.1.2",
+            "resolved": "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222",
+            "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/promptly": {
+            "version": "3.2.0",
+            "resolved": "https://registry.yarnpkg.com/promptly/-/promptly-3.2.0.tgz#a5517fbbf59bd31c1751d4e1d9bef1714f42b9d8",
+            "integrity": "sha512-WnR9obtgW+rG4oUV3hSnNGl1pHm3V1H/qD9iJBumGSmVsSC5HpZOLuu8qdMb6yCItGfT7dcRszejr/5P3i9Pug==",
+            "dependencies": {
+                "read": "^1.0.4"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-4.0.1.tgz#326c3250776c7044cd19655ccbfadf2e065a045c",
+            "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
+            "dependencies": {
+                "agent-base": "^6.0.0",
+                "debug": "4",
+                "http-proxy-agent": "^4.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "lru-cache": "^5.1.1",
+                "pac-proxy-agent": "^4.1.0",
+                "proxy-from-env": "^1.0.0",
+                "socks-proxy-agent": "^5.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/proxy-agent/node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/proxy-agent/node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/raw-body": {
+            "version": "2.4.1",
+            "resolved": "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c",
+            "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+            "dependencies": {
+                "bytes": "3.1.0",
+                "http-errors": "1.7.3",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/read": {
+            "version": "1.0.7",
+            "resolved": "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4",
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+            "dependencies": {
+                "mute-stream": "~0.0.4"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/readable-stream/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/readdir-glob": {
+            "version": "1.1.1",
+            "resolved": "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.1.tgz#f0e10bb7bf7bfa7e0add8baffdc54c3f7dbee6c4",
+            "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+            "dependencies": {
+                "minimatch": "^3.0.4"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/semver": {
+            "version": "7.3.5",
+            "resolved": "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/setprototypeof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683",
+            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/slice-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/smart-buffer": {
+            "version": "4.1.0",
+            "resolved": "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba",
+            "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/socks": {
+            "version": "2.6.1",
+            "resolved": "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e",
+            "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+            "dependencies": {
+                "ip": "^1.1.5",
+                "smart-buffer": "^4.1.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/socks-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz#032fb583048a29ebffec2e6a73fca0761f48177e",
+            "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+            "dependencies": {
+                "agent-base": "^6.0.2",
+                "debug": "4",
+                "socks": "^2.3.3"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/source-map-support": {
+            "version": "0.5.19",
+            "resolved": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61",
+            "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/string-width": {
+            "version": "4.2.2",
+            "resolved": "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5",
+            "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dependencies": {
+                "ansi-regex": "^5.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/table": {
+            "version": "6.7.1",
+            "resolved": "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2",
+            "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+            "dependencies": {
+                "ajv": "^8.0.1",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.truncate": "^4.4.2",
+                "slice-ansi": "^4.0.0",
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/tslib": {
+            "version": "2.3.0",
+            "resolved": "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e",
+            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dependencies": {
+                "prelude-ls": "~1.1.2"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/url/node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/xml2js/node_modules/sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/xregexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943",
+            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/yaml": {
+            "version": "1.10.2",
+            "resolved": "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            }
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+        },
+        "packages/waf/node_modules/aws-cdk/node_modules/zip-stream": {
+            "version": "4.1.0",
+            "resolved": "https://registry.yarnpkg.com/zip-stream/-/zip-stream-4.1.0.tgz#51dd326571544e36aa3f756430b313576dc8fc79",
+            "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+            "dependencies": {
+                "archiver-utils": "^2.1.0",
+                "compress-commons": "^4.1.0",
+                "readable-stream": "^3.6.0"
             }
         },
         "packages/waf/node_modules/diff-sequences": {
@@ -24669,8 +26401,12 @@
             "version": "file:packages/waf",
             "requires": {
                 "@aws-cdk/assert": "^1.111.0",
+                "@aws-cdk/aws-ec2": "1.111.0",
+                "@aws-cdk/aws-wafv2": "1.111.0",
+                "@aws-cdk/core": "1.111.0",
                 "@types/jest": "^27.0.2",
                 "@types/node": "16.9.4",
+                "aws-cdk": "1.111.0",
                 "jest": "^26.4.2",
                 "source-map-support": "^0.5.16",
                 "ts-jest": "^26.5.6",
@@ -24678,6 +26414,282 @@
                 "typescript": "^4.4.3"
             },
             "dependencies": {
+                "@aws-cdk/assets": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.111.0.tgz",
+                    "integrity": "sha512-O1jZ0cZNxqjSc0tknbecEZZYw5VJxFLsruQT8WguUR0cW2+B6ukdyZw6NBZxAMDrXavWDbqiR/1rdchvm5c+QQ==",
+                    "requires": {
+                        "@aws-cdk/core": "1.111.0",
+                        "@aws-cdk/cx-api": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/aws-cloudwatch": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.111.0.tgz",
+                    "integrity": "sha512-VdJrl53JJKpvK3tPJOGW46rq4BkVci1UaR2scJYzrFEvlUpnTk4TRrGWUZQ3h/A6tgJnitfY4JMhvuwLWGKOuQ==",
+                    "requires": {
+                        "@aws-cdk/aws-iam": "1.111.0",
+                        "@aws-cdk/core": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/aws-ec2": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.111.0.tgz",
+                    "integrity": "sha512-fCB4WYPWJj7yAH5Q+0mSJRPE2zIIpCpf+14NhkyPdClrSyPrDuFWPoZDiBXm0ejY0shhmcLDLyt27zzzQ+MbaA==",
+                    "requires": {
+                        "@aws-cdk/aws-cloudwatch": "1.111.0",
+                        "@aws-cdk/aws-iam": "1.111.0",
+                        "@aws-cdk/aws-kms": "1.111.0",
+                        "@aws-cdk/aws-logs": "1.111.0",
+                        "@aws-cdk/aws-s3": "1.111.0",
+                        "@aws-cdk/aws-s3-assets": "1.111.0",
+                        "@aws-cdk/aws-ssm": "1.111.0",
+                        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                        "@aws-cdk/core": "1.111.0",
+                        "@aws-cdk/cx-api": "1.111.0",
+                        "@aws-cdk/region-info": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/aws-events": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.111.0.tgz",
+                    "integrity": "sha512-oYQtwyAUQheDF4BL2t6V9uRRd+3aLTMje/Y744JoxELEHPkP1EiEutg3kI0TER/S1BZ/E35wVkj3tR420p3QJg==",
+                    "requires": {
+                        "@aws-cdk/aws-iam": "1.111.0",
+                        "@aws-cdk/core": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/aws-iam": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.111.0.tgz",
+                    "integrity": "sha512-ha0Lv0iudBeuzOlBP5eadoaVf4fASyLDmcBg99f7gHImITaS2T5JqEFY4YRUYjwoJtAUkHTVIcMF2KanWORaIw==",
+                    "requires": {
+                        "@aws-cdk/core": "1.111.0",
+                        "@aws-cdk/region-info": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/aws-kms": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.111.0.tgz",
+                    "integrity": "sha512-m5wu7jRXBHsaevjBrBEjOWmXr9JjyAQWE6m2ONeAw+oNhXt3WZkGzjwIdRbJwX4wOqFv6tjcCvjRzoiKYVEscQ==",
+                    "requires": {
+                        "@aws-cdk/aws-iam": "1.111.0",
+                        "@aws-cdk/core": "1.111.0",
+                        "@aws-cdk/cx-api": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/aws-logs": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.111.0.tgz",
+                    "integrity": "sha512-GmVLxVU8axHGL5Yd/HlKz/1ViMNJfl+HC9VO0r132XUcVpSX94ergOJFkdM5oJnjJaLdvzW2ZGtgv0anuAa9mQ==",
+                    "requires": {
+                        "@aws-cdk/aws-cloudwatch": "1.111.0",
+                        "@aws-cdk/aws-iam": "1.111.0",
+                        "@aws-cdk/aws-kms": "1.111.0",
+                        "@aws-cdk/aws-s3-assets": "1.111.0",
+                        "@aws-cdk/core": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/aws-s3": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.111.0.tgz",
+                    "integrity": "sha512-xZiJv/RjN1Cv4dqt9TxNAzw3wxqpPfsV9TQ9EDqzWc9f7ESMUj34+r2DSGHimLIf8WFvy4rFAYXY7akP9v77jA==",
+                    "requires": {
+                        "@aws-cdk/aws-events": "1.111.0",
+                        "@aws-cdk/aws-iam": "1.111.0",
+                        "@aws-cdk/aws-kms": "1.111.0",
+                        "@aws-cdk/core": "1.111.0",
+                        "@aws-cdk/cx-api": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/aws-s3-assets": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.111.0.tgz",
+                    "integrity": "sha512-viKjW0TE+k23HpddxHUO6j+rCQBKmUYuIqvyhYD8p8tnsgmwBNKlLexiDghkd24+RmkFQMhQmrQrT4niSJffEw==",
+                    "requires": {
+                        "@aws-cdk/assets": "1.111.0",
+                        "@aws-cdk/aws-iam": "1.111.0",
+                        "@aws-cdk/aws-kms": "1.111.0",
+                        "@aws-cdk/aws-s3": "1.111.0",
+                        "@aws-cdk/core": "1.111.0",
+                        "@aws-cdk/cx-api": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/aws-ssm": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.111.0.tgz",
+                    "integrity": "sha512-/rBwM0j8n78Ih62nnJ2d86hoChWid6BN0qEKYiK/1RqrWyXWpNAVADW0rK1Ous8L0qC1rHOFTCoxDVuIM6+VdQ==",
+                    "requires": {
+                        "@aws-cdk/aws-iam": "1.111.0",
+                        "@aws-cdk/aws-kms": "1.111.0",
+                        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                        "@aws-cdk/core": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/aws-wafv2": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/aws-wafv2/-/aws-wafv2-1.111.0.tgz",
+                    "integrity": "sha512-E0WbM5Hjbt6KtQEDjD70p67gpzm5eKnADlTT+khGEXptqAtcIIDEMqTpPKS2mmvoYX/MwMMv3THNAU9zgrRTbA==",
+                    "requires": {
+                        "@aws-cdk/core": "1.111.0",
+                        "constructs": "^3.3.69"
+                    }
+                },
+                "@aws-cdk/cloud-assembly-schema": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.111.0.tgz",
+                    "integrity": "sha512-Ql59HF7PDLQJislHAVhTZE8JHUtb5zikCjHseOuvWh3c5f5jjJ4i7pq9N6wjfamjfC7JGQ7LmRSXP61NIc3aNQ==",
+                    "requires": {
+                        "jsonschema": "^1.4.0",
+                        "semver": "^7.3.5"
+                    },
+                    "dependencies": {
+                        "jsonschema": {
+                            "version": "1.4.0",
+                            "bundled": true
+                        },
+                        "lru-cache": {
+                            "version": "6.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "yallist": "^4.0.0"
+                            }
+                        },
+                        "semver": {
+                            "version": "7.3.5",
+                            "bundled": true,
+                            "requires": {
+                                "lru-cache": "^6.0.0"
+                            }
+                        },
+                        "yallist": {
+                            "version": "4.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "@aws-cdk/core": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.111.0.tgz",
+                    "integrity": "sha512-ptI43hFZ6yClzyBbCQh1LZgy3b8Z0ekkb6XYCf1BtmqmimvQJOyBc68nfn+NaO2uGDRMor2XhkN9qIRpInSR4w==",
+                    "requires": {
+                        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                        "@aws-cdk/cx-api": "1.111.0",
+                        "@aws-cdk/region-info": "1.111.0",
+                        "@balena/dockerignore": "^1.0.2",
+                        "constructs": "^3.3.69",
+                        "fs-extra": "^9.1.0",
+                        "ignore": "^5.1.8",
+                        "minimatch": "^3.0.4"
+                    },
+                    "dependencies": {
+                        "@balena/dockerignore": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "at-least-node": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "balanced-match": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "brace-expansion": {
+                            "version": "1.1.11",
+                            "bundled": true,
+                            "requires": {
+                                "balanced-match": "^1.0.0",
+                                "concat-map": "0.0.1"
+                            }
+                        },
+                        "concat-map": {
+                            "version": "0.0.1",
+                            "bundled": true
+                        },
+                        "fs-extra": {
+                            "version": "9.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "at-least-node": "^1.0.0",
+                                "graceful-fs": "^4.2.0",
+                                "jsonfile": "^6.0.1",
+                                "universalify": "^2.0.0"
+                            }
+                        },
+                        "graceful-fs": {
+                            "version": "4.2.6",
+                            "bundled": true
+                        },
+                        "ignore": {
+                            "version": "5.1.8",
+                            "bundled": true
+                        },
+                        "jsonfile": {
+                            "version": "6.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.6",
+                                "universalify": "^2.0.0"
+                            }
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "bundled": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        },
+                        "universalify": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "@aws-cdk/cx-api": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.111.0.tgz",
+                    "integrity": "sha512-dGYu+3LapX3Gv4+68kOIQ2igIbAGCqNGcs5+8CFHqilBeRb31FyT5mU5yE3Hkp/+RW0Zy0T+MgCFcu0WXHgJBw==",
+                    "requires": {
+                        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                        "semver": "^7.3.5"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "6.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "yallist": "^4.0.0"
+                            }
+                        },
+                        "semver": {
+                            "version": "7.3.5",
+                            "bundled": true,
+                            "requires": {
+                                "lru-cache": "^6.0.0"
+                            }
+                        },
+                        "yallist": {
+                            "version": "4.0.0",
+                            "bundled": true
+                        }
+                    }
+                },
+                "@aws-cdk/region-info": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.111.0.tgz",
+                    "integrity": "sha512-xUqNPkg5cEV/df1aSle2cc+yasgyOtFPMXw53PYMTArwfmHMsXb5Lna0lsFddMx4heO+be5XYUrWVijIiPHMIQ=="
+                },
                 "@types/jest": {
                     "version": "27.4.1",
                     "dev": true,
@@ -24693,6 +26705,1335 @@
                 "ansi-styles": {
                     "version": "5.2.0",
                     "dev": true
+                },
+                "aws-cdk": {
+                    "version": "1.111.0",
+                    "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.111.0.tgz",
+                    "integrity": "sha512-RUxaIDjJvCfUADVqAJtwJ3XUxWKPurjxbw8oIhannvGmM1w2fIgXSm8Jx1ZN91rYLiBfkLtQMaggwvPP7BH55g==",
+                    "requires": {
+                        "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                        "@aws-cdk/cloudformation-diff": "1.111.0",
+                        "@aws-cdk/cx-api": "1.111.0",
+                        "@aws-cdk/region-info": "1.111.0",
+                        "archiver": "^5.3.0",
+                        "aws-sdk": "^2.848.0",
+                        "camelcase": "^6.2.0",
+                        "cdk-assets": "1.111.0",
+                        "colors": "^1.4.0",
+                        "decamelize": "^5.0.0",
+                        "fs-extra": "^9.1.0",
+                        "glob": "^7.1.7",
+                        "json-diff": "^0.5.4",
+                        "minimatch": ">=3.0",
+                        "promptly": "^3.2.0",
+                        "proxy-agent": "^4.0.1",
+                        "semver": "^7.3.5",
+                        "source-map-support": "^0.5.19",
+                        "table": "^6.7.1",
+                        "uuid": "^8.3.2",
+                        "wrap-ansi": "^7.0.0",
+                        "yaml": "1.10.2",
+                        "yargs": "^16.2.0"
+                    },
+                    "dependencies": {
+                        "@aws-cdk/cfnspec": {
+                            "version": "1.111.0",
+                            "requires": {
+                                "md5": "^2.3.0"
+                            }
+                        },
+                        "@aws-cdk/cloud-assembly-schema": {
+                            "version": "1.111.0",
+                            "requires": {
+                                "jsonschema": "^1.4.0",
+                                "semver": "^7.3.5"
+                            }
+                        },
+                        "@aws-cdk/cloudformation-diff": {
+                            "version": "1.111.0",
+                            "requires": {
+                                "@aws-cdk/cfnspec": "1.111.0",
+                                "@types/node": "^10.17.60",
+                                "colors": "^1.4.0",
+                                "diff": "^5.0.0",
+                                "fast-deep-equal": "^3.1.3",
+                                "string-width": "^4.2.2",
+                                "table": "^6.7.1"
+                            }
+                        },
+                        "@aws-cdk/cx-api": {
+                            "version": "1.111.0",
+                            "requires": {
+                                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                                "semver": "^7.3.5"
+                            }
+                        },
+                        "@aws-cdk/region-info": {
+                            "version": "1.111.0"
+                        },
+                        "@tootallnate/once": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82",
+                            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+                        },
+                        "@types/node": {
+                            "version": "10.17.60",
+                            "resolved": "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b",
+                            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+                        },
+                        "agent-base": {
+                            "version": "6.0.2",
+                            "resolved": "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77",
+                            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+                            "requires": {
+                                "debug": "4"
+                            }
+                        },
+                        "ajv": {
+                            "version": "8.6.0",
+                            "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-8.6.0.tgz#60cc45d9c46a477d80d92c48076d972c342e5720",
+                            "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
+                            "requires": {
+                                "fast-deep-equal": "^3.1.1",
+                                "json-schema-traverse": "^1.0.0",
+                                "require-from-string": "^2.0.2",
+                                "uri-js": "^4.2.2"
+                            }
+                        },
+                        "ansi-regex": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75",
+                            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+                        },
+                        "ansi-styles": {
+                            "version": "4.3.0",
+                            "resolved": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937",
+                            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                            "requires": {
+                                "color-convert": "^2.0.1"
+                            }
+                        },
+                        "archiver": {
+                            "version": "5.3.0",
+                            "resolved": "https://registry.yarnpkg.com/archiver/-/archiver-5.3.0.tgz#dd3e097624481741df626267564f7dd8640a45ba",
+                            "integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
+                            "requires": {
+                                "archiver-utils": "^2.1.0",
+                                "async": "^3.2.0",
+                                "buffer-crc32": "^0.2.1",
+                                "readable-stream": "^3.6.0",
+                                "readdir-glob": "^1.0.0",
+                                "tar-stream": "^2.2.0",
+                                "zip-stream": "^4.1.0"
+                            }
+                        },
+                        "archiver-utils": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2",
+                            "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+                            "requires": {
+                                "glob": "^7.1.4",
+                                "graceful-fs": "^4.2.0",
+                                "lazystream": "^1.0.0",
+                                "lodash.defaults": "^4.2.0",
+                                "lodash.difference": "^4.5.0",
+                                "lodash.flatten": "^4.4.0",
+                                "lodash.isplainobject": "^4.0.6",
+                                "lodash.union": "^4.6.0",
+                                "normalize-path": "^3.0.0",
+                                "readable-stream": "^2.0.0"
+                            },
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "2.3.7",
+                                    "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57",
+                                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                                    "requires": {
+                                        "core-util-is": "~1.0.0",
+                                        "inherits": "~2.0.3",
+                                        "isarray": "~1.0.0",
+                                        "process-nextick-args": "~2.0.0",
+                                        "safe-buffer": "~5.1.1",
+                                        "string_decoder": "~1.1.1",
+                                        "util-deprecate": "~1.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "ast-types": {
+                            "version": "0.13.4",
+                            "resolved": "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782",
+                            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+                            "requires": {
+                                "tslib": "^2.0.1"
+                            }
+                        },
+                        "astral-regex": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31",
+                            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+                        },
+                        "async": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720",
+                            "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+                        },
+                        "at-least-node": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2",
+                            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+                        },
+                        "aws-sdk": {
+                            "version": "2.932.0",
+                            "resolved": "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.932.0.tgz#43da32ab6de58a0eac6c7976feb6c9879fe09e7c",
+                            "integrity": "sha512-U6MWUtFD0npWa+ReVEgm0fCIM0fMOYahFp14GLv8fC+BWOTvh5Iwt/gF8NrLomx42bBjA1Abaw6yhmiaSJDQHQ==",
+                            "requires": {
+                                "buffer": "4.9.2",
+                                "events": "1.1.1",
+                                "ieee754": "1.1.13",
+                                "jmespath": "0.15.0",
+                                "querystring": "0.2.0",
+                                "sax": "1.2.1",
+                                "url": "0.10.3",
+                                "uuid": "3.3.2",
+                                "xml2js": "0.4.19"
+                            },
+                            "dependencies": {
+                                "buffer": {
+                                    "version": "4.9.2",
+                                    "resolved": "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8",
+                                    "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+                                    "requires": {
+                                        "base64-js": "^1.0.2",
+                                        "ieee754": "^1.1.4",
+                                        "isarray": "^1.0.0"
+                                    },
+                                    "dependencies": {
+                                        "ieee754": {
+                                            "version": "1.2.1",
+                                            "resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352",
+                                            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+                                        }
+                                    }
+                                },
+                                "ieee754": {
+                                    "version": "1.1.13",
+                                    "resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84",
+                                    "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+                                },
+                                "uuid": {
+                                    "version": "3.3.2",
+                                    "resolved": "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131",
+                                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+                                }
+                            }
+                        },
+                        "balanced-match": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee",
+                            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+                        },
+                        "base64-js": {
+                            "version": "1.5.1",
+                            "resolved": "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a",
+                            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+                        },
+                        "bl": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a",
+                            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+                            "requires": {
+                                "buffer": "^5.5.0",
+                                "inherits": "^2.0.4",
+                                "readable-stream": "^3.4.0"
+                            }
+                        },
+                        "brace-expansion": {
+                            "version": "1.1.11",
+                            "resolved": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+                            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                            "requires": {
+                                "balanced-match": "^1.0.0",
+                                "concat-map": "0.0.1"
+                            }
+                        },
+                        "buffer": {
+                            "version": "5.7.1",
+                            "resolved": "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0",
+                            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+                            "requires": {
+                                "base64-js": "^1.3.1",
+                                "ieee754": "^1.1.13"
+                            }
+                        },
+                        "buffer-crc32": {
+                            "version": "0.2.13",
+                            "resolved": "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242",
+                            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+                        },
+                        "buffer-from": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef",
+                            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+                        },
+                        "bytes": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6",
+                            "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+                        },
+                        "camelcase": {
+                            "version": "6.2.0",
+                            "resolved": "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809",
+                            "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
+                        },
+                        "cdk-assets": {
+                            "version": "1.111.0",
+                            "requires": {
+                                "@aws-cdk/cloud-assembly-schema": "1.111.0",
+                                "@aws-cdk/cx-api": "1.111.0",
+                                "archiver": "^5.3.0",
+                                "aws-sdk": "^2.848.0",
+                                "glob": "^7.1.7",
+                                "mime": "^2.5.2",
+                                "yargs": "^16.2.0"
+                            }
+                        },
+                        "charenc": {
+                            "version": "0.0.2",
+                            "resolved": "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667",
+                            "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+                        },
+                        "cli-color": {
+                            "version": "0.1.7",
+                            "resolved": "https://registry.yarnpkg.com/cli-color/-/cli-color-0.1.7.tgz#adc3200fa471cc211b0da7f566b71e98b9d67347",
+                            "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
+                            "requires": {
+                                "es5-ext": "0.8.x"
+                            }
+                        },
+                        "cliui": {
+                            "version": "7.0.4",
+                            "resolved": "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f",
+                            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+                            "requires": {
+                                "string-width": "^4.2.0",
+                                "strip-ansi": "^6.0.0",
+                                "wrap-ansi": "^7.0.0"
+                            }
+                        },
+                        "color-convert": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3",
+                            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                            "requires": {
+                                "color-name": "~1.1.4"
+                            }
+                        },
+                        "color-name": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2",
+                            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+                        },
+                        "colors": {
+                            "version": "1.4.0",
+                            "resolved": "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78",
+                            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+                        },
+                        "compress-commons": {
+                            "version": "4.1.1",
+                            "resolved": "https://registry.yarnpkg.com/compress-commons/-/compress-commons-4.1.1.tgz#df2a09a7ed17447642bad10a85cc9a19e5c42a7d",
+                            "integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+                            "requires": {
+                                "buffer-crc32": "^0.2.13",
+                                "crc32-stream": "^4.0.2",
+                                "normalize-path": "^3.0.0",
+                                "readable-stream": "^3.6.0"
+                            }
+                        },
+                        "concat-map": {
+                            "version": "0.0.1",
+                            "resolved": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+                            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                        },
+                        "core-util-is": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+                            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                        },
+                        "crc-32": {
+                            "version": "1.2.0",
+                            "resolved": "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208",
+                            "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+                            "requires": {
+                                "exit-on-epipe": "~1.0.1",
+                                "printj": "~1.1.0"
+                            }
+                        },
+                        "crc32-stream": {
+                            "version": "4.0.2",
+                            "resolved": "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-4.0.2.tgz#c922ad22b38395abe9d3870f02fa8134ed709007",
+                            "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+                            "requires": {
+                                "crc-32": "^1.2.0",
+                                "readable-stream": "^3.4.0"
+                            }
+                        },
+                        "crypt": {
+                            "version": "0.0.2",
+                            "resolved": "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b",
+                            "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+                        },
+                        "data-uri-to-buffer": {
+                            "version": "3.0.1",
+                            "resolved": "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636",
+                            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+                        },
+                        "debug": {
+                            "version": "4.3.1",
+                            "resolved": "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee",
+                            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                            "requires": {
+                                "ms": "2.1.2"
+                            }
+                        },
+                        "decamelize": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.0.tgz#88358157b010ef133febfd27c18994bd80c6215b",
+                            "integrity": "sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w=="
+                        },
+                        "deep-is": {
+                            "version": "0.1.3",
+                            "resolved": "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34",
+                            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+                        },
+                        "degenerator": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.yarnpkg.com/degenerator/-/degenerator-2.2.0.tgz#49e98c11fa0293c5b26edfbb52f15729afcdb254",
+                            "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+                            "requires": {
+                                "ast-types": "^0.13.2",
+                                "escodegen": "^1.8.1",
+                                "esprima": "^4.0.0"
+                            }
+                        },
+                        "depd": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9",
+                            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+                        },
+                        "diff": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b",
+                            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+                        },
+                        "difflib": {
+                            "version": "0.2.4",
+                            "resolved": "https://registry.yarnpkg.com/difflib/-/difflib-0.2.4.tgz#b5e30361a6db023176d562892db85940a718f47e",
+                            "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
+                            "requires": {
+                                "heap": ">= 0.2.0"
+                            }
+                        },
+                        "dreamopt": {
+                            "version": "0.6.0",
+                            "resolved": "https://registry.yarnpkg.com/dreamopt/-/dreamopt-0.6.0.tgz#d813ccdac8d39d8ad526775514a13dda664d6b4b",
+                            "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
+                            "requires": {
+                                "wordwrap": ">=0.0.2"
+                            }
+                        },
+                        "emoji-regex": {
+                            "version": "8.0.0",
+                            "resolved": "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37",
+                            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+                        },
+                        "end-of-stream": {
+                            "version": "1.4.4",
+                            "resolved": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0",
+                            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+                            "requires": {
+                                "once": "^1.4.0"
+                            }
+                        },
+                        "es5-ext": {
+                            "version": "0.8.2",
+                            "resolved": "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.8.2.tgz#aba8d9e1943a895ac96837a62a39b3f55ecd94ab",
+                            "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs="
+                        },
+                        "escalade": {
+                            "version": "3.1.1",
+                            "resolved": "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40",
+                            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+                        },
+                        "escodegen": {
+                            "version": "1.14.3",
+                            "resolved": "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503",
+                            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+                            "requires": {
+                                "esprima": "^4.0.1",
+                                "estraverse": "^4.2.0",
+                                "esutils": "^2.0.2",
+                                "optionator": "^0.8.1"
+                            }
+                        },
+                        "esprima": {
+                            "version": "4.0.1",
+                            "resolved": "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71",
+                            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+                        },
+                        "estraverse": {
+                            "version": "4.3.0",
+                            "resolved": "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d",
+                            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+                        },
+                        "esutils": {
+                            "version": "2.0.3",
+                            "resolved": "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64",
+                            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+                        },
+                        "events": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924",
+                            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+                        },
+                        "exit-on-epipe": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692",
+                            "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
+                        },
+                        "fast-deep-equal": {
+                            "version": "3.1.3",
+                            "resolved": "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525",
+                            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+                        },
+                        "fast-levenshtein": {
+                            "version": "2.0.6",
+                            "resolved": "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917",
+                            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+                        },
+                        "file-uri-to-path": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba",
+                            "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg=="
+                        },
+                        "fs-constants": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad",
+                            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+                        },
+                        "fs-extra": {
+                            "version": "9.1.0",
+                            "resolved": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d",
+                            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                            "requires": {
+                                "at-least-node": "^1.0.0",
+                                "graceful-fs": "^4.2.0",
+                                "jsonfile": "^6.0.1",
+                                "universalify": "^2.0.0"
+                            }
+                        },
+                        "fs.realpath": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f",
+                            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+                        },
+                        "ftp": {
+                            "version": "0.3.10",
+                            "resolved": "https://registry.yarnpkg.com/ftp/-/ftp-0.3.10.tgz#9197d861ad8142f3e63d5a83bfe4c59f7330885d",
+                            "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+                            "requires": {
+                                "readable-stream": "1.1.x",
+                                "xregexp": "2.0.0"
+                            },
+                            "dependencies": {
+                                "isarray": {
+                                    "version": "0.0.1",
+                                    "resolved": "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf",
+                                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                                },
+                                "readable-stream": {
+                                    "version": "1.1.14",
+                                    "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9",
+                                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                                    "requires": {
+                                        "core-util-is": "~1.0.0",
+                                        "inherits": "~2.0.1",
+                                        "isarray": "0.0.1",
+                                        "string_decoder": "~0.10.x"
+                                    }
+                                },
+                                "string_decoder": {
+                                    "version": "0.10.31",
+                                    "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94",
+                                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                                }
+                            }
+                        },
+                        "get-caller-file": {
+                            "version": "2.0.5",
+                            "resolved": "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e",
+                            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+                        },
+                        "get-uri": {
+                            "version": "3.0.2",
+                            "resolved": "https://registry.yarnpkg.com/get-uri/-/get-uri-3.0.2.tgz#f0ef1356faabc70e1f9404fa3b66b2ba9bfc725c",
+                            "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+                            "requires": {
+                                "@tootallnate/once": "1",
+                                "data-uri-to-buffer": "3",
+                                "debug": "4",
+                                "file-uri-to-path": "2",
+                                "fs-extra": "^8.1.0",
+                                "ftp": "^0.3.10"
+                            },
+                            "dependencies": {
+                                "fs-extra": {
+                                    "version": "8.1.0",
+                                    "resolved": "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0",
+                                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+                                    "requires": {
+                                        "graceful-fs": "^4.2.0",
+                                        "jsonfile": "^4.0.0",
+                                        "universalify": "^0.1.0"
+                                    }
+                                },
+                                "jsonfile": {
+                                    "version": "4.0.0",
+                                    "resolved": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb",
+                                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss="
+                                },
+                                "universalify": {
+                                    "version": "0.1.2",
+                                    "resolved": "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66",
+                                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+                                }
+                            }
+                        },
+                        "glob": {
+                            "version": "7.1.7",
+                            "resolved": "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90",
+                            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        },
+                        "graceful-fs": {
+                            "version": "4.2.6",
+                            "resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee",
+                            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+                        },
+                        "heap": {
+                            "version": "0.2.6",
+                            "resolved": "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac",
+                            "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+                        },
+                        "http-errors": {
+                            "version": "1.7.3",
+                            "resolved": "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06",
+                            "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+                            "requires": {
+                                "depd": "~1.1.2",
+                                "inherits": "2.0.4",
+                                "setprototypeof": "1.1.1",
+                                "statuses": ">= 1.5.0 < 2",
+                                "toidentifier": "1.0.0"
+                            }
+                        },
+                        "http-proxy-agent": {
+                            "version": "4.0.1",
+                            "resolved": "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a",
+                            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+                            "requires": {
+                                "@tootallnate/once": "1",
+                                "agent-base": "6",
+                                "debug": "4"
+                            }
+                        },
+                        "https-proxy-agent": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2",
+                            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+                            "requires": {
+                                "agent-base": "6",
+                                "debug": "4"
+                            }
+                        },
+                        "iconv-lite": {
+                            "version": "0.4.24",
+                            "resolved": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b",
+                            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                            "requires": {
+                                "safer-buffer": ">= 2.1.2 < 3"
+                            }
+                        },
+                        "ieee754": {
+                            "version": "1.2.1",
+                            "resolved": "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352",
+                            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+                        },
+                        "inflight": {
+                            "version": "1.0.6",
+                            "resolved": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+                            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                            "requires": {
+                                "once": "^1.3.0",
+                                "wrappy": "1"
+                            }
+                        },
+                        "inherits": {
+                            "version": "2.0.4",
+                            "resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c",
+                            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                        },
+                        "ip": {
+                            "version": "1.1.5",
+                            "resolved": "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a",
+                            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+                        },
+                        "is-buffer": {
+                            "version": "1.1.6",
+                            "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be",
+                            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d",
+                            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                        },
+                        "jmespath": {
+                            "version": "0.15.0",
+                            "resolved": "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217",
+                            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+                        },
+                        "json-diff": {
+                            "version": "0.5.4",
+                            "resolved": "https://registry.yarnpkg.com/json-diff/-/json-diff-0.5.4.tgz#7bc8198c441756632aab66c7d9189d365a7a035a",
+                            "integrity": "sha512-q5Xmx9QXNOzOzIlMoYtLrLiu4Jl/Ce2bn0CNcv54PhyH89CI4GWlGVDye8ei2Ijt9R3U+vsWPsXpLUNob8bs8Q==",
+                            "requires": {
+                                "cli-color": "~0.1.6",
+                                "difflib": "~0.2.1",
+                                "dreamopt": "~0.6.0"
+                            }
+                        },
+                        "json-schema-traverse": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2",
+                            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                        },
+                        "jsonfile": {
+                            "version": "6.1.0",
+                            "resolved": "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae",
+                            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                            "requires": {
+                                "universalify": "^2.0.0"
+                            }
+                        },
+                        "jsonschema": {
+                            "version": "1.4.0",
+                            "resolved": "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2",
+                            "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
+                        },
+                        "lazystream": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4",
+                            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+                            "requires": {
+                                "readable-stream": "^2.0.5"
+                            },
+                            "dependencies": {
+                                "readable-stream": {
+                                    "version": "2.3.7",
+                                    "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57",
+                                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                                    "requires": {
+                                        "core-util-is": "~1.0.0",
+                                        "inherits": "~2.0.3",
+                                        "isarray": "~1.0.0",
+                                        "process-nextick-args": "~2.0.0",
+                                        "safe-buffer": "~5.1.1",
+                                        "string_decoder": "~1.1.1",
+                                        "util-deprecate": "~1.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "levn": {
+                            "version": "0.3.0",
+                            "resolved": "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee",
+                            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+                            "requires": {
+                                "prelude-ls": "~1.1.2",
+                                "type-check": "~0.3.2"
+                            }
+                        },
+                        "lodash.clonedeep": {
+                            "version": "4.5.0",
+                            "resolved": "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef",
+                            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+                        },
+                        "lodash.defaults": {
+                            "version": "4.2.0",
+                            "resolved": "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c",
+                            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+                        },
+                        "lodash.difference": {
+                            "version": "4.5.0",
+                            "resolved": "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c",
+                            "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+                        },
+                        "lodash.flatten": {
+                            "version": "4.4.0",
+                            "resolved": "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f",
+                            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+                        },
+                        "lodash.isplainobject": {
+                            "version": "4.0.6",
+                            "resolved": "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb",
+                            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                        },
+                        "lodash.truncate": {
+                            "version": "4.4.2",
+                            "resolved": "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193",
+                            "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
+                        },
+                        "lodash.union": {
+                            "version": "4.6.0",
+                            "resolved": "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88",
+                            "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+                        },
+                        "lru-cache": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94",
+                            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                            "requires": {
+                                "yallist": "^4.0.0"
+                            }
+                        },
+                        "md5": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f",
+                            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+                            "requires": {
+                                "charenc": "0.0.2",
+                                "crypt": "0.0.2",
+                                "is-buffer": "~1.1.6"
+                            }
+                        },
+                        "mime": {
+                            "version": "2.5.2",
+                            "resolved": "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe",
+                            "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "resolved": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+                            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009",
+                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                        },
+                        "mute-stream": {
+                            "version": "0.0.8",
+                            "resolved": "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d",
+                            "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+                        },
+                        "netmask": {
+                            "version": "2.0.2",
+                            "resolved": "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7",
+                            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
+                        },
+                        "normalize-path": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65",
+                            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+                        },
+                        "once": {
+                            "version": "1.4.0",
+                            "resolved": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+                            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                            "requires": {
+                                "wrappy": "1"
+                            }
+                        },
+                        "optionator": {
+                            "version": "0.8.3",
+                            "resolved": "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495",
+                            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+                            "requires": {
+                                "deep-is": "~0.1.3",
+                                "fast-levenshtein": "~2.0.6",
+                                "levn": "~0.3.0",
+                                "prelude-ls": "~1.1.2",
+                                "type-check": "~0.3.2",
+                                "word-wrap": "~1.2.3"
+                            }
+                        },
+                        "pac-proxy-agent": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz#66883eeabadc915fc5e95457324cb0f0ac78defb",
+                            "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
+                            "requires": {
+                                "@tootallnate/once": "1",
+                                "agent-base": "6",
+                                "debug": "4",
+                                "get-uri": "3",
+                                "http-proxy-agent": "^4.0.1",
+                                "https-proxy-agent": "5",
+                                "pac-resolver": "^4.1.0",
+                                "raw-body": "^2.2.0",
+                                "socks-proxy-agent": "5"
+                            }
+                        },
+                        "pac-resolver": {
+                            "version": "4.2.0",
+                            "resolved": "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-4.2.0.tgz#b82bcb9992d48166920bc83c7542abb454bd9bdd",
+                            "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+                            "requires": {
+                                "degenerator": "^2.2.0",
+                                "ip": "^1.1.5",
+                                "netmask": "^2.0.1"
+                            }
+                        },
+                        "path-is-absolute": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+                            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+                        },
+                        "prelude-ls": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54",
+                            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+                        },
+                        "printj": {
+                            "version": "1.1.2",
+                            "resolved": "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222",
+                            "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
+                        },
+                        "process-nextick-args": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2",
+                            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                        },
+                        "promptly": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.yarnpkg.com/promptly/-/promptly-3.2.0.tgz#a5517fbbf59bd31c1751d4e1d9bef1714f42b9d8",
+                            "integrity": "sha512-WnR9obtgW+rG4oUV3hSnNGl1pHm3V1H/qD9iJBumGSmVsSC5HpZOLuu8qdMb6yCItGfT7dcRszejr/5P3i9Pug==",
+                            "requires": {
+                                "read": "^1.0.4"
+                            }
+                        },
+                        "proxy-agent": {
+                            "version": "4.0.1",
+                            "resolved": "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-4.0.1.tgz#326c3250776c7044cd19655ccbfadf2e065a045c",
+                            "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
+                            "requires": {
+                                "agent-base": "^6.0.0",
+                                "debug": "4",
+                                "http-proxy-agent": "^4.0.0",
+                                "https-proxy-agent": "^5.0.0",
+                                "lru-cache": "^5.1.1",
+                                "pac-proxy-agent": "^4.1.0",
+                                "proxy-from-env": "^1.0.0",
+                                "socks-proxy-agent": "^5.0.0"
+                            },
+                            "dependencies": {
+                                "lru-cache": {
+                                    "version": "5.1.1",
+                                    "resolved": "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920",
+                                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                                    "requires": {
+                                        "yallist": "^3.0.2"
+                                    }
+                                },
+                                "yallist": {
+                                    "version": "3.1.1",
+                                    "resolved": "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd",
+                                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+                                }
+                            }
+                        },
+                        "proxy-from-env": {
+                            "version": "1.1.0",
+                            "resolved": "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2",
+                            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+                        },
+                        "punycode": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec",
+                            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+                        },
+                        "querystring": {
+                            "version": "0.2.0",
+                            "resolved": "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620",
+                            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+                        },
+                        "raw-body": {
+                            "version": "2.4.1",
+                            "resolved": "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c",
+                            "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+                            "requires": {
+                                "bytes": "3.1.0",
+                                "http-errors": "1.7.3",
+                                "iconv-lite": "0.4.24",
+                                "unpipe": "1.0.0"
+                            }
+                        },
+                        "read": {
+                            "version": "1.0.7",
+                            "resolved": "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4",
+                            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+                            "requires": {
+                                "mute-stream": "~0.0.4"
+                            }
+                        },
+                        "readable-stream": {
+                            "version": "3.6.0",
+                            "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198",
+                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                            "requires": {
+                                "inherits": "^2.0.3",
+                                "string_decoder": "^1.1.1",
+                                "util-deprecate": "^1.0.1"
+                            },
+                            "dependencies": {
+                                "safe-buffer": {
+                                    "version": "5.2.1",
+                                    "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6",
+                                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+                                },
+                                "string_decoder": {
+                                    "version": "1.3.0",
+                                    "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e",
+                                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                                    "requires": {
+                                        "safe-buffer": "~5.2.0"
+                                    }
+                                }
+                            }
+                        },
+                        "readdir-glob": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.1.tgz#f0e10bb7bf7bfa7e0add8baffdc54c3f7dbee6c4",
+                            "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+                            "requires": {
+                                "minimatch": "^3.0.4"
+                            }
+                        },
+                        "require-directory": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42",
+                            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+                        },
+                        "require-from-string": {
+                            "version": "2.0.2",
+                            "resolved": "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909",
+                            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+                        },
+                        "safe-buffer": {
+                            "version": "5.1.2",
+                            "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d",
+                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                        },
+                        "safer-buffer": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a",
+                            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+                        },
+                        "sax": {
+                            "version": "1.2.1",
+                            "resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a",
+                            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+                        },
+                        "semver": {
+                            "version": "7.3.5",
+                            "resolved": "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7",
+                            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                            "requires": {
+                                "lru-cache": "^6.0.0"
+                            }
+                        },
+                        "setprototypeof": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683",
+                            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+                        },
+                        "slice-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b",
+                            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+                            "requires": {
+                                "ansi-styles": "^4.0.0",
+                                "astral-regex": "^2.0.0",
+                                "is-fullwidth-code-point": "^3.0.0"
+                            }
+                        },
+                        "smart-buffer": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba",
+                            "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+                        },
+                        "socks": {
+                            "version": "2.6.1",
+                            "resolved": "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e",
+                            "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+                            "requires": {
+                                "ip": "^1.1.5",
+                                "smart-buffer": "^4.1.0"
+                            }
+                        },
+                        "socks-proxy-agent": {
+                            "version": "5.0.1",
+                            "resolved": "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz#032fb583048a29ebffec2e6a73fca0761f48177e",
+                            "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+                            "requires": {
+                                "agent-base": "^6.0.2",
+                                "debug": "4",
+                                "socks": "^2.3.3"
+                            }
+                        },
+                        "source-map": {
+                            "version": "0.6.1",
+                            "resolved": "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263",
+                            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                        },
+                        "source-map-support": {
+                            "version": "0.5.19",
+                            "resolved": "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61",
+                            "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+                            "requires": {
+                                "buffer-from": "^1.0.0",
+                                "source-map": "^0.6.0"
+                            }
+                        },
+                        "statuses": {
+                            "version": "1.5.0",
+                            "resolved": "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c",
+                            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        },
+                        "string-width": {
+                            "version": "4.2.2",
+                            "resolved": "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5",
+                            "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+                            "requires": {
+                                "emoji-regex": "^8.0.0",
+                                "is-fullwidth-code-point": "^3.0.0",
+                                "strip-ansi": "^6.0.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532",
+                            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                            "requires": {
+                                "ansi-regex": "^5.0.0"
+                            }
+                        },
+                        "table": {
+                            "version": "6.7.1",
+                            "resolved": "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2",
+                            "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+                            "requires": {
+                                "ajv": "^8.0.1",
+                                "lodash.clonedeep": "^4.5.0",
+                                "lodash.truncate": "^4.4.2",
+                                "slice-ansi": "^4.0.0",
+                                "string-width": "^4.2.0",
+                                "strip-ansi": "^6.0.0"
+                            }
+                        },
+                        "tar-stream": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287",
+                            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+                            "requires": {
+                                "bl": "^4.0.3",
+                                "end-of-stream": "^1.4.1",
+                                "fs-constants": "^1.0.0",
+                                "inherits": "^2.0.3",
+                                "readable-stream": "^3.1.1"
+                            }
+                        },
+                        "toidentifier": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553",
+                            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+                        },
+                        "tslib": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e",
+                            "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+                        },
+                        "type-check": {
+                            "version": "0.3.2",
+                            "resolved": "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72",
+                            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                            "requires": {
+                                "prelude-ls": "~1.1.2"
+                            }
+                        },
+                        "universalify": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717",
+                            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+                        },
+                        "unpipe": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec",
+                            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+                        },
+                        "uri-js": {
+                            "version": "4.4.1",
+                            "resolved": "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e",
+                            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+                            "requires": {
+                                "punycode": "^2.1.0"
+                            }
+                        },
+                        "url": {
+                            "version": "0.10.3",
+                            "resolved": "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64",
+                            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+                            "requires": {
+                                "punycode": "1.3.2",
+                                "querystring": "0.2.0"
+                            },
+                            "dependencies": {
+                                "punycode": {
+                                    "version": "1.3.2",
+                                    "resolved": "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d",
+                                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+                                }
+                            }
+                        },
+                        "util-deprecate": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+                            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                        },
+                        "uuid": {
+                            "version": "8.3.2",
+                            "resolved": "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2",
+                            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                        },
+                        "word-wrap": {
+                            "version": "1.2.3",
+                            "resolved": "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c",
+                            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+                        },
+                        "wordwrap": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb",
+                            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+                        },
+                        "wrap-ansi": {
+                            "version": "7.0.0",
+                            "resolved": "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43",
+                            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+                            "requires": {
+                                "ansi-styles": "^4.0.0",
+                                "string-width": "^4.1.0",
+                                "strip-ansi": "^6.0.0"
+                            }
+                        },
+                        "wrappy": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+                            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                        },
+                        "xml2js": {
+                            "version": "0.4.19",
+                            "resolved": "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7",
+                            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+                            "requires": {
+                                "sax": ">=0.6.0",
+                                "xmlbuilder": "~9.0.1"
+                            },
+                            "dependencies": {
+                                "sax": {
+                                    "version": "1.2.4",
+                                    "resolved": "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9",
+                                    "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+                                }
+                            }
+                        },
+                        "xmlbuilder": {
+                            "version": "9.0.7",
+                            "resolved": "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d",
+                            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+                        },
+                        "xregexp": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943",
+                            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+                        },
+                        "y18n": {
+                            "version": "5.0.8",
+                            "resolved": "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55",
+                            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+                        },
+                        "yallist": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72",
+                            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+                        },
+                        "yaml": {
+                            "version": "1.10.2",
+                            "resolved": "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b",
+                            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+                        },
+                        "yargs": {
+                            "version": "16.2.0",
+                            "resolved": "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66",
+                            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+                            "requires": {
+                                "cliui": "^7.0.2",
+                                "escalade": "^3.1.1",
+                                "get-caller-file": "^2.0.5",
+                                "require-directory": "^2.1.1",
+                                "string-width": "^4.2.0",
+                                "y18n": "^5.0.5",
+                                "yargs-parser": "^20.2.2"
+                            }
+                        },
+                        "yargs-parser": {
+                            "version": "20.2.9",
+                            "resolved": "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee",
+                            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+                        },
+                        "zip-stream": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.yarnpkg.com/zip-stream/-/zip-stream-4.1.0.tgz#51dd326571544e36aa3f756430b313576dc8fc79",
+                            "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+                            "requires": {
+                                "archiver-utils": "^2.1.0",
+                                "compress-commons": "^4.1.0",
+                                "readable-stream": "^3.6.0"
+                            }
+                        }
+                    }
                 },
                 "diff-sequences": {
                     "version": "27.5.1",
@@ -28088,21 +31429,10 @@
                 "constructs": "^3.3.69"
             }
         },
-        "@aws-cdk/aws-wafv2": {
-            "version": "1.165.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-wafv2/-/aws-wafv2-1.165.0.tgz",
-            "integrity": "sha512-Ax/mGrYc9ttx2zDjkTxuTIVlR9d7VPAfQhZ79hx1y0V6NReHOtP/KgCNZMVEym5e96FEAIJ1r+wlZuzt5NAWYQ==",
-            "peer": true,
-            "requires": {
-                "@aws-cdk/core": "1.165.0",
-                "constructs": "^3.3.69"
-            }
-        },
         "@aws-cdk/cfnspec": {
             "version": "1.168.0",
             "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.168.0.tgz",
             "integrity": "sha512-OOwIS0/DNPsQJdgcgr1KBVRDCZD/oKteOS1ZYwwVqLhmHpX+wKRjNmWRVhPbzWha7r0ugfbuEqG9DXvJbYkLvQ==",
-            "dev": true,
             "requires": {
                 "fs-extra": "^9.1.0",
                 "md5": "^2.3.0"
@@ -28145,7 +31475,6 @@
             "version": "1.168.0",
             "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.168.0.tgz",
             "integrity": "sha512-sFfmJjB5vwiToXgUkEyme0TRuV70lOeW4a68uhovw56Fn2hCdijHlJLSshTNXk13Z/RXdLvI2UcIcZ1hABLKOQ==",
-            "dev": true,
             "requires": {
                 "@aws-cdk/cfnspec": "1.168.0",
                 "@types/node": "^10.17.60",
@@ -28159,8 +31488,7 @@
                 "@types/node": {
                     "version": "10.17.60",
                     "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-                    "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-                    "dev": true
+                    "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
                 }
             }
         },
@@ -29393,8 +32721,7 @@
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "base": {
             "version": "0.11.2",
@@ -29426,7 +32753,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -29508,8 +32834,7 @@
         "camelcase": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-            "dev": true
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         },
         "caniuse-lite": {
             "version": "1.0.30001370",
@@ -29530,7 +32855,6 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -29643,7 +32967,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
             "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-            "dev": true,
             "requires": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
@@ -29703,8 +33026,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "constructs": {
             "version": "3.4.51",
@@ -29794,8 +33116,7 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-            "dev": true
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
         },
         "decimal.js": {
             "version": "10.3.1",
@@ -30197,7 +33518,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
             "requires": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -30243,8 +33563,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
         },
         "fsevents": {
             "version": "2.3.2",
@@ -30267,8 +33586,7 @@
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
         "get-package-type": {
             "version": "0.1.0",
@@ -30295,7 +33613,6 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -30335,8 +33652,7 @@
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "has-value": {
             "version": "1.0.0",
@@ -30467,7 +33783,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -30476,8 +33791,7 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "is-accessor-descriptor": {
             "version": "1.0.0",
@@ -31246,7 +34560,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dev": true,
             "requires": {
                 "p-locate": "^4.1.0"
             }
@@ -31361,7 +34674,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -31595,7 +34907,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -31638,7 +34949,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
             }
@@ -31647,7 +34957,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
             "requires": {
                 "p-limit": "^2.2.0"
             }
@@ -31655,8 +34964,7 @@
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "parse-json": {
             "version": "5.2.0",
@@ -31685,14 +34993,12 @@
         "path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
         },
         "path-key": {
             "version": "3.1.1",
@@ -31863,8 +35169,7 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
         },
         "require-from-string": {
             "version": "2.0.2",
@@ -31874,8 +35179,7 @@
         "require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-            "dev": true
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
         },
         "resolve": {
             "version": "1.22.1",
@@ -32198,14 +35502,12 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-            "dev": true
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
         },
         "set-value": {
             "version": "2.0.1",
@@ -32665,7 +35967,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
             "requires": {
                 "has-flag": "^4.0.0"
             }
@@ -33009,9 +36310,7 @@
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "optional": true
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "v8-compile-cache-lib": {
             "version": "3.0.1",
@@ -33119,8 +36418,7 @@
         "which-module": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
-            "dev": true
+            "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q=="
         },
         "word-wrap": {
             "version": "1.2.3",
@@ -33131,7 +36429,6 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
             "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -33141,8 +36438,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "write-file-atomic": {
             "version": "3.0.3",
@@ -33178,8 +36474,7 @@
         "y18n": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-            "dev": true
+            "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
         },
         "yallist": {
             "version": "4.0.0",
@@ -33191,7 +36486,6 @@
             "version": "15.4.1",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
             "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-            "dev": true,
             "requires": {
                 "cliui": "^6.0.0",
                 "decamelize": "^1.2.0",
@@ -33210,7 +36504,6 @@
                     "version": "18.1.3",
                     "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
                     "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-                    "dev": true,
                     "requires": {
                         "camelcase": "^5.0.0",
                         "decamelize": "^1.2.0"

--- a/packages/waf/lib/waf.ts
+++ b/packages/waf/lib/waf.ts
@@ -1,5 +1,5 @@
 import { Construct } from '@aws-cdk/core';
-import * as wafv2 from '@aws-cdk/aws-wafv2';1
+import * as wafv2 from '@aws-cdk/aws-wafv2';
 
 export interface WebApplicationFirewallProps {
   /**

--- a/packages/waf/package.json
+++ b/packages/waf/package.json
@@ -25,12 +25,16 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
+    "@aws-cdk/aws-ec2": "1.111.0",
+    "@aws-cdk/aws-wafv2": "1.111.0",
+    "@aws-cdk/core": "1.111.0",
+    "aws-cdk": "1.111.0",
     "source-map-support": "^0.5.16"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-ec2": "^1.111.0",
-    "@aws-cdk/aws-wafv2": "^1.111.0",
-    "@aws-cdk/core": "^1.111.0",
-    "aws-cdk": "^1.111.0"
+    "@aws-cdk/aws-ec2": "1.111.0",
+    "@aws-cdk/aws-wafv2": "1.111.0",
+    "@aws-cdk/core": "1.111.0",
+    "aws-cdk": "1.111.0"
   }
 }


### PR DESCRIPTION
A client is looking to add the WAF to their Cloudfront distribution so I have made some small refactors to make this a little easier in the upstream repo. The main changes are just making a few more props optional and allowing a list of associations to be provided. 

This is a breaking change so there will need to be a major version bump. 