### PR TITLE
Static hosting custom header policies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7870,7 +7870,7 @@
         },
         "packages/static-hosting": {
             "name": "@aligent/cdk-static-hosting",
-            "version": "0.1.5",
+            "version": "0.1.13",
             "license": "GPL-3.0-only",
             "dependencies": {
                 "@aws-cdk/aws-cloudfront": "1.180.0",

--- a/packages/static-hosting/README.md
+++ b/packages/static-hosting/README.md
@@ -2,10 +2,11 @@
 
 ## Overview
 
-This repository defines a CDK construct for hosting a static website on AWS using S3 and CloudFront. 
+This repository defines a CDK construct for hosting a static website on AWS using S3 and CloudFront.
 It can be imported and used within CDK applications.
 
 ## Example
+
 The following CDK snippet can be used to provision a static hosting stack using this construct.
 
 ```
@@ -43,3 +44,46 @@ new HostingStack(app, 'hosting-stack', {
 });
 
 ```
+
+### Response Header Policies
+
+You can initialize [Response Headers Policies], map them and pass to the construct.
+
+1. Create a policy
+
+    ```sh
+    // Creating a custom response headers policy -- all parameters optional
+    const reportUriPolicy = new ResponseHeadersPolicy(this, 'ReportUriPolicy', {
+        responseHeadersPolicyName: 'ReportUriPolicy',
+        comment: 'To enable CSP Reporting',
+        customHeadersBehavior: {
+            customHeaders: [
+                { 
+                    header: 'content-security-policy-report-only', 
+                    value: `default-src 'none'; form-action 'none'; frame-ancestors 'none'; report-uri https://some-report-uri-domain.report-uri.com/r/t/csp/wizard`, 
+                    override: true 
+                },
+            ],
+        },
+    });
+    ```
+
+2. Attached policy to desired cache behavior or path
+
+    ```sh
+    const responseHeaders: ResponseHeaderMappings[] = [{
+        header: reportUriPolicy,
+        pathPatterns: ['/au*', '/nz*']
+        attachToDefault: false
+    }];
+    ```
+
+    If you should attached the policy to the Default Behavior, set `attachToDefault: true`
+
+3. Include the config as props
+
+    ```sh
+    new StaticHosting(this, 'pwa-stack', {...staticProps, ...{behaviors, customOriginConfigs, responseHeaders}});
+    ```
+
+[Response Headers Policies]:https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-cloudfront.ResponseHeadersPolicy.html

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -68,11 +68,21 @@ export interface StaticHostingProps {
      * Optional WAF ARN 
      */
     webAclArn?: string;
+
+    /**
+     * Response Header policies
+     */
+    responseHeaders?: ResponseHeaderMappings[];
 }
 
 interface remapPath {
     from: string,
     to: string
+}
+
+export interface ResponseHeaderMappings {
+    header: ResponseHeadersPolicy,
+    behaviors: string[]
 }
 
 export class StaticHosting extends Construct {
@@ -300,6 +310,21 @@ export class StaticHosting extends Construct {
                 description: 'CSP Header',
                 value: cspHeader,
                 exportName: `${exportPrefix}CSPHeader`
+            });
+        }
+        
+        /**
+         * Response Header policies
+         */
+        if (props.responseHeaders) {
+            const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
+            props.responseHeaders.forEach( (policyMapping) => {
+                policyMapping.behaviors.forEach(behavior => {
+                    cfnDistribution.addOverride(
+                        `Properties.DistributionConfig.CacheBehaviors[${props.behaviors?.findIndex(behavior => behavior.pathPattern == behavior)}].ResponseHeadersPolicyId`,
+                        policyMapping.header.responseHeadersPolicyId
+                    );
+                });
             });
         }
 

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -320,7 +320,7 @@ export class StaticHosting extends Construct {
             const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
 
             /**
-             * If we prepend the custom origin config,
+             * If we prepend custom origin configs,
              *  it would change the array indexes.
              */
             let numberOfCustomBehaviors = 0;

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -72,7 +72,7 @@ export interface StaticHostingProps {
     /**
      * Response Header policies
      */
-    responseHeaders?: ResponseHeaderMappings[];
+    responseHeadersPolicies?: ResponseHeaderMappings[];
 }
 
 interface remapPath {
@@ -83,7 +83,7 @@ interface remapPath {
 export interface ResponseHeaderMappings {
     header: ResponseHeadersPolicy,
     pathPatterns: string[],
-    attachedToDefault?: boolean
+    attachToDefault?: boolean
 }
 
 export class StaticHosting extends Construct {
@@ -319,7 +319,7 @@ export class StaticHosting extends Construct {
          * This feature helps to attached custom ResponseHeadersPolicies to 
          *  the cache behaviors
          */
-        if (props.responseHeaders) {
+        if (props.responseHeadersPolicies) {
             const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
 
             /**
@@ -331,15 +331,15 @@ export class StaticHosting extends Construct {
                 numberOfCustomBehaviors = props.customOriginConfigs?.reduce((acc, current) => acc + current.behaviors.length, 0)!;
             }
             
-            props.responseHeaders.forEach( (policyMapping) => {
+            props.responseHeadersPolicies.forEach( (policyMapping) => {
                 /**
                  * If the policy should be attached to default behavior
                  */
-                if (policyMapping.attachedToDefault) {
+                if (policyMapping.attachToDefault) {
                     cfnDistribution.addOverride(
-                        `Properties.DistributionConfig.CacheBehaviors.` +
-                            `DefaultCacheBehavior` +
-                            `.ResponseHeadersPolicyId`,
+                        `Properties.DistributionConfig.` +
+                            `DefaultCacheBehavior.` +
+                            `ResponseHeadersPolicyId`,
                     policyMapping.header.responseHeadersPolicyId
                 )};
                 /**
@@ -362,6 +362,12 @@ export class StaticHosting extends Construct {
                         policyMapping.header.responseHeadersPolicyId
                     )};
                 });
+            });
+            
+            new CfnOutput(this, 'Response Header Policies', {
+                description: 'Response Header Policies',
+                value: JSON.stringify(props.responseHeadersPolicies),
+                exportName: `${exportPrefix}CSPHeader`
             });
         }
             

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -320,7 +320,7 @@ export class StaticHosting extends Construct {
             const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
             props.responseHeaders.forEach( (policyMapping) => {
                 policyMapping.pathPatterns.forEach(path => cfnDistribution.addOverride(
-                    `Properties.DistributionConfig.CacheBehaviors[${props.behaviors?.findIndex(behavior => {return behavior.pathPattern === path})}].ResponseHeadersPolicyId`,
+                    `Properties.DistributionConfig.CacheBehaviors.${props.behaviors?.findIndex(behavior => {return behavior.pathPattern === path})}.ResponseHeadersPolicyId`,
                     policyMapping.header.responseHeadersPolicyId
                 ));
             });

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -345,7 +345,7 @@ export class StaticHosting extends Construct {
                     new CfnOutput(this, `response header policies ${policyMapping.header.node.id} default`, {
                         description: `response header policy mappings`,
                         value: `{ path: "default", policy: "${policyMapping.header.responseHeadersPolicyId}" }`,
-                        exportName: `${exportPrefix}_header_policy_default`
+                        exportName: `${exportPrefix}HeaderPolicy-default`
                     });
                 };
                 /**
@@ -370,7 +370,7 @@ export class StaticHosting extends Construct {
                         new CfnOutput(this, `response header policies ${policyMapping.header.node.id} ${path.replace(/\W/g, '')}`, {
                             description: `response header policy mappings`,
                             value: `{ path: "${path}", policy: "${policyMapping.header.responseHeadersPolicyId}"}`,
-                            exportName: `${exportPrefix}_header_policy_${path.replace(/\W/g, '')}`
+                            exportName: `${exportPrefix}HeaderPolicy-${path.replace(/\W/g, '')}`
                         });
                     };
                 });

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -363,6 +363,7 @@ export class StaticHosting extends Construct {
                     )};
                 });
             });
+        }
             
         if (publisherGroup) {
             const cloudFrontInvalidationPolicyStatement = new PolicyStatement({

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -82,7 +82,7 @@ interface remapPath {
 
 export interface ResponseHeaderMappings {
     header: ResponseHeadersPolicy,
-    behaviors: string[]
+    pathPatterns: string[]
 }
 
 export class StaticHosting extends Construct {
@@ -312,19 +312,17 @@ export class StaticHosting extends Construct {
                 exportName: `${exportPrefix}CSPHeader`
             });
         }
-        
+
         /**
          * Response Header policies
          */
         if (props.responseHeaders) {
             const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
             props.responseHeaders.forEach( (policyMapping) => {
-                policyMapping.behaviors.forEach(behavior => {
-                    cfnDistribution.addOverride(
-                        `Properties.DistributionConfig.CacheBehaviors[${props.behaviors?.findIndex(behavior => behavior.pathPattern == behavior)}].ResponseHeadersPolicyId`,
-                        policyMapping.header.responseHeadersPolicyId
-                    );
-                });
+                policyMapping.pathPatterns.forEach(path => cfnDistribution.addOverride(
+                    `Properties.DistributionConfig.CacheBehaviors[${props.behaviors?.findIndex(behavior => {return behavior.pathPattern === path})}].ResponseHeadersPolicyId`,
+                    policyMapping.header.responseHeadersPolicyId
+                ));
             });
         }
 

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -342,12 +342,9 @@ export class StaticHosting extends Construct {
                             `ResponseHeadersPolicyId`,
                     policyMapping.header.responseHeadersPolicyId
                     );
-                    new CfnOutput(this, `response header policies${policyMapping.header.node.id}`, {
-                        description: `response header policy mappings: ${policyMapping.header.responseHeadersPolicyId} `,
-                        value: `{
-                            path: "default", 
-                            policy: "${policyMapping.header.responseHeadersPolicyId}"
-                        }`,
+                    new CfnOutput(this, `response header policies ${policyMapping.header.node.id} default`, {
+                        description: `response header policy mappings`,
+                        value: `{ path: "default", policy: "${policyMapping.header.responseHeadersPolicyId}" }`,
                         exportName: `${exportPrefix}_header_policy_default`
                     });
                 };
@@ -370,12 +367,9 @@ export class StaticHosting extends Construct {
                                 `.ResponseHeadersPolicyId`,
                         policyMapping.header.responseHeadersPolicyId
                         );
-                        new CfnOutput(this, `response header policies${policyMapping.header.node.id}`, {
-                            description: `response header policy mappings: ${policyMapping.header.responseHeadersPolicyId} `,
-                            value: `{
-                                path: "${path}", 
-                                policy: "${policyMapping.header.responseHeadersPolicyId}"
-                            }`,
+                        new CfnOutput(this, `response header policies ${policyMapping.header.node.id} ${path.replace(/\W/g, '')}`, {
+                            description: `response header policy mappings`,
+                            value: `{ path: "${path}", policy: "${policyMapping.header.responseHeadersPolicyId}"}`,
                             exportName: `${exportPrefix}_header_policy_${path.replace(/\W/g, '')}`
                         });
                     };

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -341,7 +341,16 @@ export class StaticHosting extends Construct {
                             `DefaultCacheBehavior.` +
                             `ResponseHeadersPolicyId`,
                     policyMapping.header.responseHeadersPolicyId
-                )};
+                    );
+                    new CfnOutput(this, `response header policies${policyMapping.header.responseHeadersPolicyId}`, {
+                        description: `response header policy mappings: ${policyMapping.header.responseHeadersPolicyId} `,
+                        value: `{
+                            path: "default", 
+                            policy: "${policyMapping.header.responseHeadersPolicyId}"
+                        }`,
+                        exportName: `${exportPrefix}_header_policy_default`
+                    });
+                };
                 /**
                  * If the policy should be attached to
                  *  specified path patterns
@@ -360,14 +369,17 @@ export class StaticHosting extends Construct {
                                 `${behaviorIndex}` +
                                 `.ResponseHeadersPolicyId`,
                         policyMapping.header.responseHeadersPolicyId
-                    )};
+                        );
+                        new CfnOutput(this, `response header policies${policyMapping.header.responseHeadersPolicyId}`, {
+                            description: `response header policy mappings: ${policyMapping.header.responseHeadersPolicyId} `,
+                            value: `{
+                                path: "${path}", 
+                                policy: "${policyMapping.header.responseHeadersPolicyId}"
+                            }`,
+                            exportName: `${exportPrefix}_header_policy_${path.replace(/\W/g, '')}`
+                        });
+                    };
                 });
-            });
-            
-            new CfnOutput(this, 'Response Header Policies', {
-                description: 'Response Header Policies',
-                value: JSON.stringify(props.responseHeadersPolicies),
-                exportName: `${exportPrefix}CSPHeader`
             });
         }
             

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -318,9 +318,20 @@ export class StaticHosting extends Construct {
          */
         if (props.responseHeaders) {
             const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
+
+            /**
+             * If we prepend the custom origin config,
+             *  it would change the array indexes.
+             */
+            let numberOfCustomBehaviors = 0;
+            if (props.prependCustomOriginBehaviours) {
+                numberOfCustomBehaviors = props.customOriginConfigs?.reduce((acc, current) => acc + current.behaviors.length, 0)!;
+            }
             props.responseHeaders.forEach( (policyMapping) => {
                 policyMapping.pathPatterns.forEach(path => cfnDistribution.addOverride(
-                    `Properties.DistributionConfig.CacheBehaviors.${props.behaviors?.findIndex(behavior => {return behavior.pathPattern === path})}.ResponseHeadersPolicyId`,
+                    `Properties.DistributionConfig.CacheBehaviors.` +
+                    `${props.behaviors?.findIndex(behavior => {return behavior.pathPattern === path})! + numberOfCustomBehaviors}` +
+                    `.ResponseHeadersPolicyId`,
                     policyMapping.header.responseHeadersPolicyId
                 ));
             });

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -342,7 +342,7 @@ export class StaticHosting extends Construct {
                             `ResponseHeadersPolicyId`,
                     policyMapping.header.responseHeadersPolicyId
                     );
-                    new CfnOutput(this, `response header policies${policyMapping.header.responseHeadersPolicyId}`, {
+                    new CfnOutput(this, `response header policies${policyMapping.header.node.id}`, {
                         description: `response header policy mappings: ${policyMapping.header.responseHeadersPolicyId} `,
                         value: `{
                             path: "default", 
@@ -370,7 +370,7 @@ export class StaticHosting extends Construct {
                                 `.ResponseHeadersPolicyId`,
                         policyMapping.header.responseHeadersPolicyId
                         );
-                        new CfnOutput(this, `response header policies${policyMapping.header.responseHeadersPolicyId}`, {
+                        new CfnOutput(this, `response header policies${policyMapping.header.node.id}`, {
                             description: `response header policy mappings: ${policyMapping.header.responseHeadersPolicyId} `,
                             value: `{
                                 path: "${path}", 

--- a/packages/static-hosting/package.json
+++ b/packages/static-hosting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-static-hosting",
-  "version": "0.1.5",
+  "version": "0.1.13",
   "main": "index.js",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/aligent/aws-cdk-static-hosting-stack#readme",


### PR DESCRIPTION
This feature enable us to create and attach response header policies to specified path. 
This is an optional configuration.

1. Create a policy

    ```sh
    // Creating a custom response headers policy -- all parameters optional
    const reportUriPolicy = new ResponseHeadersPolicy(this, 'ReportUriPolicy', {
        responseHeadersPolicyName: 'ReportUriPolicy',
        comment: 'To enable CSP Reporting',
        customHeadersBehavior: {
            customHeaders: [
                { 
                    header: 'content-security-policy-report-only', 
                    value: `default-src 'none'; form-action 'none'; frame-ancestors 'none'; report-uri https://some-report-uri-domain.report-uri.com/r/t/csp/wizard`, 
                    override: true 
                },
            ],
        },
    });
    ```

2. Attached policy to desired cache behavior or path

    ```sh
    const responseHeaders: ResponseHeaderMappings[] = [{
        header: reportUriPolicy,
        pathPatterns: ['/au*', '/nz*']
        attachToDefault: false
    }];
    ```

    If you should attached the policy to the Default Behavior, set `attachToDefault: true`

3. Include the config as props

    ```sh
    new StaticHosting(this, 'pwa-stack', {...staticProps, ...{behaviors, customOriginConfigs, responseHeaders}});
    ```