### PR TITLE
Add explicit allow js files to npmignore

### DIFF
--- a/packages/prerender-fargate/.npmignore
+++ b/packages/prerender-fargate/.npmignore
@@ -1,0 +1,11 @@
+*.ts
+!lib/handlers/*.ts
+!*.d.ts
+!*.js
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# Samples
+sample/

--- a/packages/prerender-proxy/.npmignore
+++ b/packages/prerender-proxy/.npmignore
@@ -1,0 +1,11 @@
+*.ts
+!lib/handlers/*.ts
+!*.d.ts
+!*.js
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# Samples
+sample/


### PR DESCRIPTION
JS files weren't being included in the npm package. This happened previously and the solution was to explicitly allow `js` files in the package.

This should hopefully fix the import package issues that @crispy101 and I were experiencing. 