### PR TITLE
JBH-615: Set is a bot header in prerender proxy repo

### DIFF
--- a/packages/prerender-proxy/lib/handlers/prerender-check.ts
+++ b/packages/prerender-proxy/lib/handlers/prerender-check.ts
@@ -10,17 +10,24 @@ export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFront
     // If the request is from a bot, is not a file and is not from prerender
     // then set the x-request-prerender header so the origin-request lambda function
     // alters the origin to prerender.io
-    if (!IS_FILE.test(request.uri) 
-        && IS_BOT.test(request.headers['user-agent'][0].value)
-        && !request.headers['x-prerender']) {
-        request.headers['x-request-prerender'] = [
-            {
-                key: 'x-request-prerender',
-                value: 'true'
-            }
-        ];
+    if (IS_BOT.test(request.headers['user-agent'][0].value)) {
+      request.headers["x-is-a-bot"] = [
+        {
+          key: "x-is-a-bot",
+          value: "true",
+        },
+      ];
+      if (!IS_FILE.test(request.uri) 
+          && !request.headers['x-prerender']) {
+          request.headers['x-request-prerender'] = [
+              {
+                  key: 'x-request-prerender',
+                  value: 'true'
+              }
+          ];
 
-        request.headers['x-prerender-host'] = [{ key: 'X-Prerender-Host', value: request.headers.host[0].value}];
+          request.headers['x-prerender-host'] = [{ key: 'X-Prerender-Host', value: request.headers.host[0].value}];
+      }
     }
 
     return request;


### PR DESCRIPTION
This is to let Origin request function to know that if the request is coming from a bot, as whitelisting user-agent header could cause to have many possible values, and caching based on their values would cause CloudFront to forward significantly more requests to the origin.