### PR TITLE
Prerender check function code cleanup

### DIFF
--- a/packages/prerender-proxy/lib/handlers/prerender-check.ts
+++ b/packages/prerender-proxy/lib/handlers/prerender-check.ts
@@ -15,12 +15,6 @@ export const handler = async (
   // then set the x-request-prerender header so the origin-request lambda function
   // alters the origin to prerender.io
   if (IS_BOT.test(request.headers["user-agent"][0].value)) {
-    request.headers["x-is-a-bot"] = [
-      {
-        key: "x-is-a-bot",
-        value: "true",
-      },
-    ];
     if (!IS_FILE.test(request.uri) && !request.headers["x-prerender"]) {
       request.headers["x-request-prerender"] = [
         {


### PR DESCRIPTION
## Prerender check function code cleanup

We have introduced following header to address some concerns with GeoIP redirect logic. 
As we are no longer required this header we shall remove it. 

**Further note:**
This header was used to check if a request coming from a crawler, and if it does, it should NOT redirect based on the GeoIP logic. Instead of using this header, we found that we could leverage,    
-  `x-prerender`
- `x-request-prerender`
headers to see it is a crawler.