### PR TITLE
Use tokens for Attribute references

### DIFF
--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -1,5 +1,5 @@
 import { Construct } from 'constructs';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, Token } from 'aws-cdk-lib';
 import { RemovalPolicy } from 'aws-cdk-lib';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
@@ -129,11 +129,11 @@ export class MeshService extends Construct {
         if (props.redis) {
             props.redis.securityGroup.addIngressRule(
                 securityGroup,
-                Port.tcp(Number(props.redis.connectionPort))
+                Port.tcp(props.redis.connectionPort)
             );
 
             environment['REDIS_ENDPOINT'] = props.redis.connectionEndPoint;
-            environment['REDIS_PORT'] = props.redis.connectionPort;
+            environment['REDIS_PORT'] = props.redis.connectionPort.toString();
         }
 
         // Construct secrets from provided ssm values

--- a/packages/graphql-mesh-server/lib/redis-construct.ts
+++ b/packages/graphql-mesh-server/lib/redis-construct.ts
@@ -4,7 +4,7 @@ import {
     CfnSubnetGroup,
     CfnParameterGroup,
 } from 'aws-cdk-lib/aws-elasticache';
-import { CfnOutput } from 'aws-cdk-lib';
+import { CfnOutput, Reference, Token } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
 export interface RedisServiceProps {
@@ -83,14 +83,10 @@ export class RedisService extends Construct {
     }
 
     public get connectionEndPoint(): string {
-        return this.cacheCluster
-            .getAtt('RedisEndpoint.Address')
-            .toString();
+        return Token.asString(this.cacheCluster.getAtt('RedisEndpoint.Address'))
     }
 
-    public get connectionPort(): string {
-        return this.cacheCluster
-            .getAtt('RedisEndpoint.Port')
-            .toString();
+    public get connectionPort(): number {
+        return Token.asNumber(this.cacheCluster.getAtt('RedisEndpoint.Port'));
     }
 }


### PR DESCRIPTION
**Description of the proposed changes**  
Update connection strings to use tokens for attribute references as they are evaluating to null when using the toString() method.

**Screenshots (if applicable)**  
Before:
![before_1](https://github.com/aligent/cdk-constructs/assets/7251527/56ad2536-5931-4866-b72d-38f02282a795)
![before](https://github.com/aligent/cdk-constructs/assets/7251527/6a41ae22-b0b8-4187-94b1-54ed6f0f5883)

After:
![after_1](https://github.com/aligent/cdk-constructs/assets/7251527/4b401e55-a11e-45b1-bc89-7f87275524ef)
![after](https://github.com/aligent/cdk-constructs/assets/7251527/4f382eae-20a1-4888-b005-4f7bb9031b00)


**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://aligent.atlassian.net/wiki/spaces/AL/pages/2728919167/Pull+Request+guidelines)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback