### PR TITLE
Feature/do 1484 enable cache for redirects

### DIFF
--- a/packages/prerender-fargate/README.md
+++ b/packages/prerender-fargate/README.md
@@ -1,15 +1,18 @@
 # Prerender in Fargate
-A construct to host [Prerender](https://github.com/prerender/prerender) in Fargate. 
+
+A construct to host [Prerender](https://github.com/prerender/prerender) in Fargate.
 
 ## Props
- - `prerenderName`: Name of the Prerender service
- - `domainName`: Domain name for Prerender
- - `vpcId`: VPC to host Prerender in
- - `bucketName`: Optional S3 bucket name
- - `expirationDays`: Optional days until items expire in bucket (default to 7 days)
- - `tokenList`: List of tokens to accept as authentication
- - `certificateArn`: Certificate arn to match the domain
- - `desiredInstanceCount`: Number of Prerender instances to run (default 1)
- - `maxInstanceCount`: Maximum number of Prerender instances to run (default 2)
- - `instanceCPU`: CPU to allocate to each instance (default 512)
- - `instanceMemory`: Amount of memory to allocate to each instance (default 1024)
+
+- `prerenderName`: Name of the Prerender service
+- `domainName`: Domain name for Prerender
+- `vpcId`: VPC to host Prerender in
+- `bucketName`: Optional S3 bucket name
+- `expirationDays`: Optional days until items expire in bucket (default to 7 days)
+- `tokenList`: List of tokens to accept as authentication
+- `certificateArn`: Certificate arn to match the domain
+- `desiredInstanceCount`: Number of Prerender instances to run (default 1)
+- `maxInstanceCount`: Maximum number of Prerender instances to run (default 2)
+- `instanceCPU`: CPU to allocate to each instance (default 512)
+- `instanceMemory`: Amount of memory to allocate to each instance (default 1024)
+- `enableRedirectCache`: Cache 301 and 302 responses, too (default false)

--- a/packages/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate.ts
@@ -22,6 +22,7 @@ export interface PrerenderOptions {
     maxInstanceCount?: number,
     instanceCPU?: number,
     instanceMemory?: number
+    enableRedirectCache?: string
 }
 
 export class PrerenderFargate extends Construct {
@@ -80,6 +81,7 @@ export class PrerenderFargate extends Construct {
                         AWS_ACCESS_KEY_ID: accessKey.accessKeyId,
                         AWS_SECRET_ACCESS_KEY: accessKey.secretAccessKey.toString(),
                         AWS_REGION: Stack.of(this).region,
+                        ENABLE_REDIRECT_CACHE: props.enableRedirectCache || "false",
                         TOKEN_LIST: props.tokenList.toString()
                     }
                 },

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -41,7 +41,7 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
     var he = require('he');
     var s3 = new (require('aws-sdk')).S3({params:{Bucket: process.env.S3_BUCKET_NAME}});
     server.use({
-            requestReceived: function(req, res, next) {
+        requestReceived: function(req, res, next) {
                 if(req.method !== 'GET' && req.method !== 'HEAD') {
                     console.log("skipping requestReceived from S3 Cache... ")
                     return next();
@@ -54,11 +54,10 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
                 }
 
                 s3.getObject({
-                        Key: key
+                    Key: key
                 }, function (err, result) {
 
                     if (!err && result) {
-                        console.log(result.Metadata);
                         console.log("Found cached object: " + key);
                         if (result.Metadata.location){
                             res.setHeader('Location', result.Metadata.location);
@@ -72,7 +71,6 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
                 });
             },
             // The pageLoaded function is a modified version of https://github.com/prerender/prerender/blob/478fa6d0a5196ea29c88c69e64e72eb5507b6d2c/lib/plugins/httpHeaders.js
-
             pageLoaded: function(req, res, next) {
                 const statusCodesToCache = ['200', '301', '302'];
                 let metaTagStatusCode = 200;

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -36,8 +36,114 @@ server.use({
 });
 
 server.use(prerender.blacklist());
-server.use(prerender.httpHeaders());
-server.use(prerender.removeScriptTags());
-server.use(s3Cache);
+
+if (process.env.ENABLE_CACHE_FOR_REDIRECTION){
+    server.use(prerender.removeScriptTags());
+    var he = require('he');
+    var s3 = new (require('aws-sdk')).S3({params:{Bucket: process.env.S3_BUCKET_NAME}});
+    server.use({
+            requestReceived: function(req, res, next) {
+                if(req.method !== 'GET' && req.method !== 'HEAD') {
+                    console.log("skipping requestReceived from S3 Cache... ")
+                    return next();
+                }
+    
+                var key = req.prerender.url;
+    
+                if (process.env.S3_PREFIX_KEY) {
+                    key = process.env.S3_PREFIX_KEY + '/' + key;
+                }
+    
+                s3.getObject({
+                        Key: key
+                }, function (err, result) {
+    
+                    if (!err && result) {
+                        console.log(result.Metadata);
+                        console.log("Found cached object: " + key);
+                        if (result.Metadata.location){
+                            res.setHeader('Location', result.Metadata.location);
+                        }
+                        return res.send(result.Metadata.httpreturncode, result.Body);
+                    } else {
+                        console.error(err);
+                    }
+    
+                    next();
+                });
+            },
+    
+            pageLoaded: function(req, res, next) {
+                const statusCodesToCache = ['200', '301', '302'];
+                let metaTagStatusCode = 200;
+                let location = '';
+    
+                if (req.prerender.content && req.prerender.renderType == 'html') {
+                    let statusMatch = /<meta[^<>]*(?:name=['"]prerender-status-code['"][^<>]*content=['"]([0-9]{3})['"]|content=['"]([0-9]{3})['"][^<>]*name=['"]prerender-status-code['"])[^<>]*>/i,
+                    headerMatch = /<meta[^<>]*(?:name=['"]prerender-header['"][^<>]*content=['"]([^'"]*?): ?([^'"]*?)['"]|content=['"]([^'"]*?): ?([^'"]*?)['"][^<>]*name=['"]prerender-header['"])[^<>]*>/gi,
+                    head = req.prerender.content.toString().split('</head>', 1).pop(),
+                    // statusCode = 200,
+                    match;
+    
+                    if (match = statusMatch.exec(head)) {
+                        metaTagStatusCode = match[1] || match[2];
+                        req.prerender.content = req.prerender.content.toString().replace(match[0], '');
+                        console.log("metaTagStatusCode: " + metaTagStatusCode);
+                    }
+    
+                    while (match = headerMatch.exec(head)) {
+                        location = he.decode(match[2] || match[4]);
+                        res.setHeader(match[1] || match[3], location);
+                        req.prerender.content = req.prerender.content.toString().replace(match[0], '');
+                    }
+    
+                    // Skip caching for the http response codes not in the list, such as 404
+                    if ( ! statusCodesToCache.includes(metaTagStatusCode.toString()) ) {
+                        console.log("metaTagStatusCode " + metaTagStatusCode + " is not in the cachable code list. Returning without caching.");
+                        return res.send(metaTagStatusCode, req.prerender.content);
+                    }
+                }
+    
+                if(req.prerender.statusCode !== 200) {
+                    return next();
+                }
+    
+                // Override req.prerender.statusCode with the StatusCode returned via the meta tag.
+                // If metaTagStatusCode is not in the statusCodesToCache array or req.prerender.statusCode is not 200, then this line wouldn't be reached. Therefore no if condition for this overriding is needed.
+                req.prerender.statusCode = metaTagStatusCode;
+                console.log("Caching the object with statusCode " + req.prerender.statusCode);
+    
+                var key = req.prerender.url;
+                var s3Metadata = {
+                    httpreturncode: req.prerender.statusCode.toString()
+                }
+    
+                if (location) {
+                    s3Metadata.location = location;
+                }
+    
+                if (process.env.S3_PREFIX_KEY) {
+                    key = process.env.S3_PREFIX_KEY + '/' + key;
+                }
+    
+                s3.putObject({
+                    Key: key,
+                    ContentType: 'text/html;charset=UTF-8',
+                    StorageClass: 'REDUCED_REDUNDANCY',
+                    Body: req.prerender.content,
+                    Metadata: s3Metadata
+                }, function(err, result) {
+                    console.log(result);
+                    if (err) console.error(err);
+    
+                    next();
+                });
+        }
+    });
+} else {
+    server.use(prerender.httpHeaders());
+    server.use(prerender.removeScriptTags());
+    server.use(s3Cache);
+}
 
 server.start();

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -37,7 +37,7 @@ server.use({
 
 server.use(prerender.blacklist());
 
-if (process.env.ENABLE_CACHE_FOR_REDIRECTION){
+if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
     server.use(prerender.removeScriptTags());
     var he = require('he');
     var s3 = new (require('aws-sdk')).S3({params:{Bucket: process.env.S3_BUCKET_NAME}});

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -46,8 +46,7 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
             // s3cache plugin - https://github.com/prerender/prerender-aws-s3-cache/blob/98707fa0f787de83aa41583682cd2c2d330a9cca/index.js
         requestReceived: function(req, res, next) {
                 if(req.method !== 'GET' && req.method !== 'HEAD') {
-                    console.log("skipping requestReceived from S3 Cache... ")
-                    return next();
+\                    return next();
                 }
 
                 var key = req.prerender.url;

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -46,7 +46,7 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
             // s3cache plugin - https://github.com/prerender/prerender-aws-s3-cache/blob/98707fa0f787de83aa41583682cd2c2d330a9cca/index.js
         requestReceived: function(req, res, next) {
                 if(req.method !== 'GET' && req.method !== 'HEAD') {
-\                    return next();
+                    return next();
                 }
 
                 var key = req.prerender.url;

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -38,7 +38,6 @@ server.use({
 server.use(prerender.blacklist());
 
 if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
-    server.use(prerender.removeScriptTags());
     var he = require('he');
     var s3 = new (require('aws-sdk')).S3({params:{Bucket: process.env.S3_BUCKET_NAME}});
     server.use({
@@ -138,8 +137,9 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
 
                     next();
                 });
-        }
-    });
+            }
+        });
+        server.use(prerender.removeScriptTags());
 } else {
     server.use(prerender.httpHeaders());
     server.use(prerender.removeScriptTags());

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -41,6 +41,9 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
     var he = require('he');
     var s3 = new (require('aws-sdk')).S3({params:{Bucket: process.env.S3_BUCKET_NAME}});
     server.use({
+            // The requestReceived and pageLoaded functions are a modified version of
+            // httpHeader plugin - https://github.com/prerender/prerender/blob/478fa6d0a5196ea29c88c69e64e72eb5507b6d2c/lib/plugins/httpHeaders.js combined with
+            // s3cache plugin - https://github.com/prerender/prerender-aws-s3-cache/blob/98707fa0f787de83aa41583682cd2c2d330a9cca/index.js
         requestReceived: function(req, res, next) {
                 if(req.method !== 'GET' && req.method !== 'HEAD') {
                     console.log("skipping requestReceived from S3 Cache... ")
@@ -62,7 +65,8 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
                         if (result.Metadata.location){
                             res.setHeader('Location', result.Metadata.location);
                         }
-                        return res.send(result.Metadata.httpreturncode, result.Body);
+                        // default 200 for legacy objects that do not have Metadata.httpreturncode defined
+                        return res.send(result.Metadata.httpreturncode || 200, result.Body);
                     } else {
                         console.error(err);
                     }
@@ -70,69 +74,61 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
                     next();
                 });
             },
-            // The pageLoaded function is a modified version of https://github.com/prerender/prerender/blob/478fa6d0a5196ea29c88c69e64e72eb5507b6d2c/lib/plugins/httpHeaders.js
-            pageLoaded: function(req, res, next) {
-                const statusCodesToCache = ['200', '301', '302'];
-                let metaTagStatusCode = 200;
-                var s3Metadata = {
-                    httpreturncode: req.prerender.statusCode.toString()
+
+        pageLoaded: function(req, res, next) {
+            const statusCodesToCache = ['200', '301', '302'];
+            var s3Metadata = {}
+
+            // Inspect prerender meta tags and update response accordingly
+            if (req.prerender.content && req.prerender.renderType == 'html') {
+                const statusMatchRegex = /<meta[^<>]*(?:name=['"]prerender-status-code['"][^<>]*content=['"]([0-9]{3})['"]|content=['"]([0-9]{3})['"][^<>]*name=['"]prerender-status-code['"])[^<>]*>/i;
+                const headerMatchRegex = /<meta[^<>]*(?:name=['"]prerender-header['"][^<>]*content=['"]([^'"]*?): ?([^'"]*?)['"]|content=['"]([^'"]*?): ?([^'"]*?)['"][^<>]*name=['"]prerender-header['"])[^<>]*>/gi
+                const head = req.prerender.content.toString().split('</head>', 1).pop()
+
+                const statusMatch = statusMatchRegex.exec(head)
+                if (statusMatch) {
+                    req.prerender.statusCode = statusMatch[1] || statusMatch[2];
+                    req.prerender.content = req.prerender.content.toString().replace(statusMatch[0], '');
                 }
 
-                if (req.prerender.content && req.prerender.renderType == 'html') {
-                    const statusMatchRegex = /<meta[^<>]*(?:name=['"]prerender-status-code['"][^<>]*content=['"]([0-9]{3})['"]|content=['"]([0-9]{3})['"][^<>]*name=['"]prerender-status-code['"])[^<>]*>/i;
-                    const headerMatchRegex = /<meta[^<>]*(?:name=['"]prerender-header['"][^<>]*content=['"]([^'"]*?): ?([^'"]*?)['"]|content=['"]([^'"]*?): ?([^'"]*?)['"][^<>]*name=['"]prerender-header['"])[^<>]*>/gi
-                    const head = req.prerender.content.toString().split('</head>', 1).pop()
-
-                    const statusMatch = statusMatchRegex.exec(head)
-                    if (statusMatch) {
-                        metaTagStatusCode = statusMatch[1] || statusMatch[2];
-                        req.prerender.content = req.prerender.content.toString().replace(statusMatch[0], '');
-                    }
-
-                    let headerMatch = headerMatchRegex.exec(head)
-                    while (headerMatch) {
-                        s3Metadata.location = he.decode(headerMatch[2] || headerMatch[4]);
-                        res.setHeader(headerMatch[1] || headerMatch[3], s3Metadata.location);
-                        req.prerender.content = req.prerender.content.toString().replace(headerMatch[0], '');
-                        headerMatch = headerMatchRegex.exec(head)
-                    }
-
-                    // Skip caching for the http response codes not in the list, such as 404
-                    if ( ! statusCodesToCache.includes(metaTagStatusCode.toString()) ) {
-                        console.log(`metaTagStatusCode ${metaTagStatusCode} for ${req.prerender.url} is not in the cachable code list. Returning without caching the result.`);
-                        return res.send(metaTagStatusCode, req.prerender.content);
-                    }
+                let headerMatch = headerMatchRegex.exec(head)
+                while (headerMatch) {
+                    s3Metadata.location = he.decode(headerMatch[2] || headerMatch[4]);
+                    res.setHeader(headerMatch[1] || headerMatch[3], s3Metadata.location);
+                    req.prerender.content = req.prerender.content.toString().replace(headerMatch[0], '');
+                    headerMatch = headerMatchRegex.exec(head)
                 }
 
-                if(req.prerender.statusCode !== 200) {
-                    return next();
+                // Skip caching for the http response codes not in the list, such as 404
+                if ( ! statusCodesToCache.includes(req.prerender.statusCode.toString()) ) {
+                    console.log(`StatusCode ${req.prerender.statusCode} for ${req.prerender.url} is not in the cachable code list. Returning without caching the result.`);
+                    return res.send(req.prerender.statusCode, req.prerender.content);
                 }
-
-                // Override req.prerender.statusCode with the StatusCode returned via the meta tag.
-                // If metaTagStatusCode is not in the statusCodesToCache array or req.prerender.statusCode is not 200, then this line wouldn't be reached. Therefore no if condition for this overriding is needed.
-                req.prerender.statusCode = metaTagStatusCode;
-                console.log(`Caching the object ${req.prerender.url} with statusCode ${metaTagStatusCode}`);
-                var key = req.prerender.url;
-
-                if (process.env.S3_PREFIX_KEY) {
-                    key = process.env.S3_PREFIX_KEY + '/' + key;
-                }
-
-                s3.putObject({
-                    Key: key,
-                    ContentType: 'text/html;charset=UTF-8',
-                    StorageClass: 'REDUCED_REDUNDANCY',
-                    Body: req.prerender.content,
-                    Metadata: s3Metadata
-                }, function(err, result) {
-                    console.log(result);
-                    if (err) console.error(err);
-
-                    next();
-                });
             }
-        });
-        server.use(prerender.removeScriptTags());
+            s3Metadata.httpreturncode = req.prerender.statusCode.toString()
+
+            console.log(`Caching the object ${req.prerender.url} with statusCode ${req.prerender.statusCode}`);
+            var key = req.prerender.url;
+
+            if (process.env.S3_PREFIX_KEY) {
+                key = process.env.S3_PREFIX_KEY + '/' + key;
+            }
+
+            s3.putObject({
+                Key: key,
+                ContentType: 'text/html;charset=UTF-8',
+                StorageClass: 'REDUCED_REDUNDANCY',
+                Body: req.prerender.content,
+                Metadata: s3Metadata
+            }, function(err, result) {
+                console.log(result);
+                if (err) console.error(err);
+
+                next();
+            });
+        }
+    });
+    server.use(prerender.removeScriptTags());
 } else {
     server.use(prerender.httpHeaders());
     server.use(prerender.removeScriptTags());

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -101,7 +101,7 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
 
                     // Skip caching for the http response codes not in the list, such as 404
                     if ( ! statusCodesToCache.includes(metaTagStatusCode.toString()) ) {
-                        console.log("metaTagStatusCode " + metaTagStatusCode + " is not in the cachable code list. Returning without caching.");
+                        console.log(`metaTagStatusCode ${metaTagStatusCode} for ${req.prerender.url} is not in the cachable code list. Returning without caching the result.`);
                         return res.send(metaTagStatusCode, req.prerender.content);
                     }
                 }
@@ -113,8 +113,7 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
                 // Override req.prerender.statusCode with the StatusCode returned via the meta tag.
                 // If metaTagStatusCode is not in the statusCodesToCache array or req.prerender.statusCode is not 200, then this line wouldn't be reached. Therefore no if condition for this overriding is needed.
                 req.prerender.statusCode = metaTagStatusCode;
-                console.log("Caching the object with statusCode " + req.prerender.statusCode);
-
+                console.log(`Caching the object ${req.prerender.url} with statusCode ${metaTagStatusCode}`);
                 var key = req.prerender.url;
 
                 if (process.env.S3_PREFIX_KEY) {


### PR DESCRIPTION
**Description of the proposed changes**  

* Let Prerender be able to cache 301 and 302 responses in the S3 bucket when explicitly enabled by enableRedirectCache flag 

**Screenshots (if applicable)**  

* cached object meta-tags for this purpose
![image](https://github.com/aligent/cdk-constructs/assets/55869976/d50417cd-e29d-42cb-863c-f60b553e4780)

**Other solutions considered (if any)**  

* N/A

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://aligent.atlassian.net/wiki/spaces/AL/pages/2728919167/Pull+Request+guidelines)

**Notes to reviewers**  
Incorporated the below existing plug-ins
* prerender.httpHeaders: https://github.com/prerender/prerender/blob/master/lib/plugins/httpHeaders.js
* S3Cache: https://github.com/prerender/prerender-aws-s3-cache/blob/master/index.js


🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback