### PR TITLE
DO-1554: Replace AWS Access Key Pair with Task Role

### DIFF
--- a/packages/prerender-fargate/index.ts
+++ b/packages/prerender-fargate/index.ts
@@ -1,4 +1,9 @@
 import { PrerenderFargate } from "./lib/prerender-fargate";
 import { PrerenderFargateOptions } from "./lib/prerender-fargate-options";
+import { PrerenderTokenUrlAssociationProps as PrerenderTokenUrlAssociationOptions } from "./lib/recaching/prerender-tokens";
 
-export { PrerenderFargate, PrerenderFargateOptions };
+export {
+  PrerenderFargate,
+  PrerenderFargateOptions,
+  PrerenderTokenUrlAssociationOptions,
+};

--- a/packages/prerender-fargate/index.ts
+++ b/packages/prerender-fargate/index.ts
@@ -1,6 +1,6 @@
 import { PrerenderFargate } from "./lib/prerender-fargate";
 import { PrerenderFargateOptions } from "./lib/prerender-fargate-options";
-import { PrerenderTokenUrlAssociationProps as PrerenderTokenUrlAssociationOptions } from "./lib/recaching/prerender-tokens";
+import { PrerenderTokenUrlAssociationOptions } from "./lib/recaching/prerender-tokens";
 
 export {
   PrerenderFargate,

--- a/packages/prerender-fargate/lib/prerender-fargate-options.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate-options.ts
@@ -1,4 +1,4 @@
-import { PrerenderTokenUrlAssociationProps } from "./recaching/prerender-tokens";
+import { PrerenderTokenUrlAssociationOptions } from "./recaching/prerender-tokens";
 
 /**
  * Options for configuring the Prerender Fargate construct.
@@ -77,5 +77,5 @@ export interface PrerenderFargateOptions {
    * }
    * ```
    */
-  tokenUrlAssociation?: PrerenderTokenUrlAssociationProps;
+  tokenUrlAssociation?: PrerenderTokenUrlAssociationOptions;
 }

--- a/packages/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate.ts
@@ -176,10 +176,10 @@ export class PrerenderFargate extends Construct {
           ),
         }
       );
-      
+
     // Grant S3 Bucket access to the task role
     this.bucket.grantReadWrite(fargateService.taskDefinition.taskRole);
-    
+
     // As the prerender service will return a 401 on all unauthorised requests
     // It should be considered healthy when receiving a 401 response
     fargateService.targetGroup.configureHealthCheck({

--- a/packages/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate.ts
@@ -6,7 +6,6 @@ import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import { HostedZone } from "aws-cdk-lib/aws-route53";
 import { Bucket, BlockPublicAccess } from "aws-cdk-lib/aws-s3";
 import * as ecrAssets from "aws-cdk-lib/aws-ecr-assets";
-import { AccessKey, User } from "aws-cdk-lib/aws-iam";
 import { Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
 import * as path from "path";
 import { PrerenderTokenUrlAssociation } from "./recaching/prerender-tokens";

--- a/packages/prerender-fargate/lib/recaching/prerender-tokens.ts
+++ b/packages/prerender-fargate/lib/recaching/prerender-tokens.ts
@@ -12,7 +12,7 @@ interface TokenUrlAssociation {
 /**
  * Interface for associating a token with a URL for prerendering.
  */
-export interface PrerenderTokenUrlAssociationProps extends StackProps {
+export interface PrerenderTokenUrlAssociationOptions extends StackProps {
   /**
    * Object containing the token and its associated URL.
    * ### Example
@@ -46,7 +46,7 @@ export class PrerenderTokenUrlAssociation extends Stack {
   constructor(
     scope: Construct,
     id: string,
-    props: PrerenderTokenUrlAssociationProps
+    props: PrerenderTokenUrlAssociationOptions
   ) {
     super(scope, id, props);
 


### PR DESCRIPTION
### DO-1554: Replace AWS Access Key Pair with Task Role

------

**Description of the proposed changes**  

*  Use the task role instead of the access key pair to access the s3 bucket
* Export  `PrerenderTokenUrlAssociationOptions`

**Screenshots (if applicable)**  

* N/A

**Other solutions considered (if any)**  

* N/A
