### PR TITLE
TF-1072: Assign distribution as class property

### DIFF
--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -383,10 +383,10 @@ export class StaticHosting extends Construct {
       errorResponses: props.enableErrorConfig ? errorResponses : [],
     };
 
-    const distribution = new Distribution(this, "BucketCdn", distributionProps);
+    this.distribution = new Distribution(this, "BucketCdn", distributionProps);
 
     if (props.overrideLogicalId) {
-      const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
+      const cfnDistribution = this.distribution.node.defaultChild as CfnDistribution;
       cfnDistribution.overrideLogicalId(props.overrideLogicalId);
     }
 

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -386,7 +386,8 @@ export class StaticHosting extends Construct {
     this.distribution = new Distribution(this, "BucketCdn", distributionProps);
 
     if (props.overrideLogicalId) {
-      const cfnDistribution = this.distribution.node.defaultChild as CfnDistribution;
+      const cfnDistribution = this.distribution.node
+        .defaultChild as CfnDistribution;
       cfnDistribution.overrideLogicalId(props.overrideLogicalId);
     }
 


### PR DESCRIPTION
**Description of the proposed changes**  

* The `distribution` property was not assigned when importing changes