### PR TITLE
Feature/do 1563 prerender logging improvement

### DIFF
--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -23,10 +23,13 @@ const server = prerender({
 
 server.use({
     requestReceived: (req, res, next) => {
-        console.log(`${new Date().toISOString()} User-Agent: "${req.get('user-agent')}" ${req.prerender.reqId} ${req.prerender.url}`);
+        // Log "x-prerender-user-agent" value forwarded from CloudFront/Lambda@edge that contains the original User-Agent value. If not present, e.g. requests from ELB, default to "user-agent" value.
+        const userAgent = req.get('x-prerender-user-agent') || req.get('user-agent');
+
+        console.log(`${new Date().toISOString()} User-Agent: "${userAgent}" ${req.prerender.reqId} ${req.prerender.url}`);
         let auth = req.headers['x-prerender-token'];
         if (!auth) {
-            console.log(`${new Date().toISOString()} "${req.get('user-agent')}" ${req.prerender.reqId} Authentication header not found.`);
+            console.log(`${new Date().toISOString()} "${userAgent}" ${req.prerender.reqId} Authentication header not found.`);
             return res.send(401);
         }
 
@@ -40,7 +43,7 @@ server.use({
             if (authenticated) break;
         }
         if (!authenticated) {
-            console.log(`${new Date().toISOString()} "${req.get('user-agent')}" ${req.prerender.reqId} Authentication Failed.`);
+            console.log(`${new Date().toISOString()} "${userAgent}" ${req.prerender.reqId} Authentication Failed.`);
             return res.send(401);
         }
 

--- a/packages/prerender-proxy/lib/handlers/prerender-check.ts
+++ b/packages/prerender-proxy/lib/handlers/prerender-check.ts
@@ -26,6 +26,14 @@ export const handler = async (
       request.headers["x-prerender-host"] = [
         { key: "X-Prerender-Host", value: request.headers.host[0].value },
       ];
+
+      // Custom header to be forwarded to Prerender service for better logging
+      request.headers["x-prerender-user-agent"] = [
+        {
+          key: "x-prerender-user-agent",
+          value: request.headers["user-agent"][0].value,
+        },
+      ];
     }
   }
 


### PR DESCRIPTION
**Description of the proposed changes**  

* Let Viewer Request Lambda@Edge function add a custom header with the original request's `User-Agent` value
* Let Prerender Fargate service consume the custom header value for logging

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback