### PR TITLE
DO-1563: (Legacy) Log custom header having the Prerender requester's …

### DIFF
--- a/packages/prerender-proxy/lib/handlers/prerender-check.ts
+++ b/packages/prerender-proxy/lib/handlers/prerender-check.ts
@@ -26,6 +26,14 @@ export const handler = async (
       request.headers["x-prerender-host"] = [
         { key: "X-Prerender-Host", value: request.headers.host[0].value },
       ];
+
+      // Custom header to be forwarded to Prerender service for better logging
+      request.headers["x-prerender-user-agent"] = [
+        {
+          key: "x-prerender-user-agent",
+          value: request.headers["user-agent"][0].value,
+        },
+      ];
     }
   }
 


### PR DESCRIPTION
**Description of the proposed changes**  

* (Legacy) Let Viewer Request Lambda@Edge function add a custom header with the original request's User-Agent value

**Screenshots (if applicable)**  

* Published as `@aligent/cdk-prerender-proxy@0.2.9-alpha` and now working as expected (`c-googlebot` is what I used for testing)
![image](https://github.com/aligent/cdk-constructs/assets/55869976/e1a5992f-40e2-4840-a036-545076e4116a)


**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback