### PR TITLE
fix bug not firing nested stack for ssm paramter creation

### DIFF
--- a/packages/prerender-fargate/lib/recaching/prerender-tokens.ts
+++ b/packages/prerender-fargate/lib/recaching/prerender-tokens.ts
@@ -1,4 +1,4 @@
-import { Stack, StackProps } from "aws-cdk-lib";
+import { NestedStack, NestedStackProps } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import { StringListParameter } from "aws-cdk-lib/aws-ssm";
 
@@ -12,7 +12,7 @@ interface TokenUrlAssociation {
 /**
  * Interface for associating a token with a URL for prerendering.
  */
-export interface PrerenderTokenUrlAssociationOptions extends StackProps {
+export interface PrerenderTokenUrlAssociationOptions extends NestedStackProps {
   /**
    * Object containing the token and its associated URL.
    * ### Example
@@ -42,7 +42,7 @@ export interface PrerenderTokenUrlAssociationOptions extends StackProps {
  * The constructor loops through the tokenUrlAssociation object and
  * creates an SSM parameter for each token.
  */
-export class PrerenderTokenUrlAssociation extends Stack {
+export class PrerenderTokenUrlAssociation extends NestedStack {
   constructor(
     scope: Construct,
     id: string,


### PR DESCRIPTION

**Description of the proposed changes**  

* Use NestedStack for the SSM Param creation to get it automatically created under the condition specified.

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback