### PR TITLE
Graphql server monitoring enhancements

### DIFF
--- a/packages/graphql-mesh-server/lib/dashboard.ts
+++ b/packages/graphql-mesh-server/lib/dashboard.ts
@@ -1,0 +1,274 @@
+import { Construct } from "constructs";
+import {
+  Metric,
+  TextWidget,
+  SingleValueWidget,
+  GraphWidget,
+  LegendPosition,
+  Dashboard as CWDashboard,
+  Column,
+  LogQueryWidget,
+} from "aws-cdk-lib/aws-cloudwatch";
+import { FargateService } from "aws-cdk-lib/aws-ecs";
+import {
+  ApplicationLoadBalancer,
+  HttpCodeElb,
+  HttpCodeTarget,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { WebApplicationFirewall } from "./web-application-firewall";
+import { LogGroup } from "aws-cdk-lib/aws-logs";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DashboardProps {
+  service: FargateService;
+  loadBalancer: ApplicationLoadBalancer;
+  firewall: WebApplicationFirewall;
+  logGroup: LogGroup;
+}
+
+export class Dashboard extends Construct {
+  constructor(scope: Construct, id: string, props: DashboardProps) {
+    super(scope, id);
+
+    // Load balancer metrics and widgets
+    const requestCountMetrics: Metric[] = [
+      props.loadBalancer.metrics.requestCount({
+        label: "Total Request Count",
+      }),
+      props.loadBalancer.metrics.httpCodeTarget(
+        HttpCodeTarget.TARGET_2XX_COUNT,
+        {
+          label: "HTTP 2xx Count",
+          color: "#69ae34",
+        }
+      ),
+      props.loadBalancer.metrics.httpCodeElb(HttpCodeElb.ELB_4XX_COUNT, {
+        label: "ELB 4xx Count",
+        color: "#f89256",
+      }),
+      props.loadBalancer.metrics.httpCodeElb(HttpCodeElb.ELB_5XX_COUNT, {
+        label: "ELB 5xx Count",
+      }),
+    ];
+
+    const targetResponseTime: Metric =
+      props.loadBalancer.metrics.targetResponseTime({
+        label: "Target Response Time",
+      });
+
+    const loadBalancerLabel = new TextWidget({
+      markdown: "# Load Balancer",
+      width: 12,
+      height: 1,
+    });
+
+    const requestCountSingleWidget = new SingleValueWidget({
+      title: "Mesh Request Count",
+      width: 12,
+      height: 4,
+      sparkline: true,
+      metrics: requestCountMetrics,
+    });
+
+    const requestCountGraphWidget = new GraphWidget({
+      title: "Mesh Request Count",
+      width: 12,
+      height: 7,
+    });
+
+    const responseTimeGraphWidget = new GraphWidget({
+      title: "Target Response Time",
+      width: 12,
+      height: 6,
+      legendPosition: LegendPosition.HIDDEN,
+    });
+    responseTimeGraphWidget.addLeftMetric(targetResponseTime);
+
+    requestCountMetrics.forEach(metric => {
+      requestCountGraphWidget.addLeftMetric(metric);
+    });
+
+    const loadBalancerWidgets = [
+      loadBalancerLabel,
+      requestCountSingleWidget,
+      requestCountGraphWidget,
+      responseTimeGraphWidget,
+    ];
+
+    // WAF metrics and widgets
+    const wafRequestMetrics: Metric[] = [
+      new Metric({
+        namespace: "AWS/WAFV2",
+        metricName: "AllowedRequests",
+        dimensionsMap: {
+          WebACL:
+            props.firewall.acl.name ||
+            "MeshHostingmeshwafWebAclD163A31D-b4zo3YLl9rkw", // TODO: get the name automatically
+          Rule: "ALL",
+          Region: "ap-southeast-2", // TODO: get the region automatically
+        },
+      }),
+    ];
+
+    const wafLabel = new TextWidget({
+      markdown: "# WAF",
+      width: 12,
+      height: 1,
+    });
+
+    const wafRequestsSingleWidget = new SingleValueWidget({
+      title: "WAF Request Count",
+      width: 12,
+      height: 4,
+      sparkline: true,
+      metrics: wafRequestMetrics,
+    });
+
+    const wafRequestsGraphWidget = new GraphWidget({
+      title: "WAF Request Count",
+      width: 12,
+      height: 7,
+    });
+    wafRequestMetrics.forEach(metric => {
+      wafRequestsGraphWidget.addLeftMetric(metric);
+    });
+
+    const wafWidgets = [
+      wafLabel,
+      wafRequestsSingleWidget,
+      wafRequestsGraphWidget,
+    ];
+
+    // Mesh Performance
+    const currentActiveTasksMetric: Metric[] = [
+      // Current no built in method to get these metrics
+      // Need to manually construct
+      new Metric({
+        namespace: "ECS/ContainerInsights",
+        metricName: "DesiredTaskCount",
+        dimensionsMap: {
+          ServiceName: props.service.serviceName,
+          ClusterName: props.service.cluster.clusterName,
+        },
+        statistic: "min",
+      }),
+      new Metric({
+        namespace: "ECS/ContainerInsights",
+        metricName: "RunningTaskCount",
+        dimensionsMap: {
+          ServiceName: props.service.serviceName,
+          ClusterName: props.service.cluster.clusterName,
+        },
+        color: "#69ae34",
+        statistic: "min",
+      }),
+      new Metric({
+        namespace: "ECS/ContainerInsights",
+        metricName: "PendingTaskCount",
+        dimensionsMap: {
+          ServiceName: props.service.serviceName,
+          ClusterName: props.service.cluster.clusterName,
+        },
+        color: "#f89256",
+        statistic: "min",
+      }),
+    ];
+
+    const taskCPUMetrics: Metric[] = [
+      props.service.metricCpuUtilization({
+        statistic: "min",
+      }),
+      props.service.metricCpuUtilization({
+        statistic: "max",
+      }),
+      props.service.metricCpuUtilization({
+        statistic: "avg",
+      }),
+    ];
+
+    const taskMemoryMetrics: Metric[] = [
+      props.service.metricMemoryUtilization({
+        statistic: "min",
+      }),
+      props.service.metricMemoryUtilization({
+        statistic: "max",
+      }),
+      props.service.metricMemoryUtilization({
+        statistic: "avg",
+      }),
+    ];
+
+    const meshPerformanceLabel = new TextWidget({
+      markdown: "# Mesh Performance",
+      width: 24,
+      height: 1,
+    });
+
+    const currentActiveTasksSingleWidget = new SingleValueWidget({
+      title: "Current Active Tasks",
+      width: 7,
+      height: 3,
+      sparkline: false,
+      metrics: currentActiveTasksMetric,
+    });
+
+    const currentActiveTasksGraphWidget = new GraphWidget({
+      title: "Current Active Tasks",
+      width: 7,
+      height: 5,
+    });
+    currentActiveTasksMetric.slice(1).forEach(metric => {
+      currentActiveTasksGraphWidget.addLeftMetric(metric);
+    });
+
+    const currentTaskWidgets = [
+      currentActiveTasksSingleWidget,
+      currentActiveTasksGraphWidget,
+    ];
+
+    const taskCPUGraphWidget = new GraphWidget({
+      title: "Mesh CPU",
+      width: 7,
+      height: 6,
+    });
+    taskCPUMetrics.forEach(metric => {
+      taskCPUGraphWidget.addLeftMetric(metric);
+    });
+
+    const taskMemoryGraphWidget = new GraphWidget({
+      title: "Mesh Memory",
+      width: 7,
+      height: 6,
+    });
+    taskMemoryMetrics.forEach(metric => {
+      taskMemoryGraphWidget.addLeftMetric(metric);
+    });
+
+    const meshPerformanceMetrics = [taskCPUGraphWidget, taskMemoryGraphWidget];
+
+    const taskLogsWidget = new LogQueryWidget({
+      title: "Application Logs",
+      width: 10,
+      height: 12,
+      queryString:
+        "fields @timestamp, @message\n| sort @timestamp desc\n| limit 25",
+      logGroupNames: [
+        props.logGroup.logGroupName,
+      ],
+    });
+
+    // Create the dashboard
+    new CWDashboard(this, "dashboard", {
+      dashboardName: "Mesh-Dashboard",
+      widgets: [
+        [new Column(...loadBalancerWidgets), new Column(...wafWidgets)],
+        [meshPerformanceLabel],
+        [
+          new Column(...currentTaskWidgets),
+          new Column(...meshPerformanceMetrics),
+          new Column(taskLogsWidget)
+        ],
+      ],
+    });
+  }
+}

--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -17,6 +17,8 @@ import {
 } from "./web-application-firewall";
 import { CfnIPSet, CfnWebACL } from "aws-cdk-lib/aws-wafv2";
 import { ScalingInterval, AdjustmentType } from "aws-cdk-lib/aws-autoscaling";
+import { ApplicationLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { LogGroup } from "aws-cdk-lib/aws-logs";
 
 export interface MeshServiceProps {
   /**
@@ -109,12 +111,19 @@ export interface MeshServiceProps {
    * Defaults to true
    */
   containerInsights?: boolean;
+  /**
+   * Log stream prefix
+   * Defaults to 'graphql-server'
+   */
+  logStreamPrefix?: string;
 }
 
 export class MeshService extends Construct {
   public readonly vpc: IVpc;
   public readonly repository: ecr.Repository;
   public readonly service: ecs.FargateService;
+  public readonly loadBalancer: ApplicationLoadBalancer;
+  public readonly logGroup: LogGroup;
   public readonly firewall: WebApplicationFirewall;
 
   constructor(scope: Construct, id: string, props: MeshServiceProps) {
@@ -205,6 +214,13 @@ export class MeshService extends Construct {
     for (const [key, ssm] of Object.entries(props.secrets)) {
       secrets[key] = ecs.Secret.fromSsmParameter(ssm);
     }
+
+    // Configure a custom log driver and group
+    this.logGroup = new LogGroup(this, "graphql-server-log", {});
+    const logDriver = ecs.LogDrivers.awsLogs({
+      streamPrefix: props.logStreamPrefix || 'graphql-server',
+      logGroup: this.logGroup,
+    })
     // Create a load-balanced Fargate service and make it public
     const fargateService =
       new ecsPatterns.ApplicationLoadBalancedFargateService(this, `fargate`, {
@@ -219,6 +235,7 @@ export class MeshService extends Construct {
           containerPort: 4000, // graphql mesh gateway port
           secrets: secrets,
           environment: environment,
+          logDriver: logDriver,
         },
         publicLoadBalancer: true, // default,
         taskSubnets: {
@@ -228,6 +245,7 @@ export class MeshService extends Construct {
       });
 
     this.service = fargateService.service;
+    this.loadBalancer = fargateService.loadBalancer;
 
     const blockedIpList = new CfnIPSet(this, "BlockedIpList", {
       addresses: props.blockedIps || [],

--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -218,9 +218,9 @@ export class MeshService extends Construct {
     // Configure a custom log driver and group
     this.logGroup = new LogGroup(this, "graphql-server-log", {});
     const logDriver = ecs.LogDrivers.awsLogs({
-      streamPrefix: props.logStreamPrefix || 'graphql-server',
+      streamPrefix: props.logStreamPrefix || "graphql-server",
       logGroup: this.logGroup,
-    })
+    });
     // Create a load-balanced Fargate service and make it public
     const fargateService =
       new ecsPatterns.ApplicationLoadBalancedFargateService(this, `fargate`, {

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -10,7 +10,7 @@ import * as ssm from "aws-cdk-lib/aws-ssm";
 import { AWSManagedRule, WebApplicationFirewall } from "./web-application-firewall";
 import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
 import { ScalingInterval } from "aws-cdk-lib/aws-autoscaling";
-import { Dashboard } from "./dashboard";
+import { PerformanceMetrics } from "./metrics";
 import { ApplicationLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 
@@ -175,7 +175,7 @@ export class MeshHosting extends Construct {
       notificationArn: props.notificationArn,
     });
 
-    new Dashboard(this, "cloudwatch", {
+    new PerformanceMetrics(this, "cloudwatch", {
       ...props,
       service: this.service,
       loadBalancer: this.loadBalancer,

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -13,6 +13,7 @@ import { ScalingInterval } from "aws-cdk-lib/aws-autoscaling";
 import { PerformanceMetrics } from "./metrics";
 import { ApplicationLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { Topic } from "aws-cdk-lib/aws-sns";
 
 export type MeshHostingProps = {
   /**
@@ -122,6 +123,10 @@ export type MeshHostingProps = {
    * Defaults to 'graphql-server'
    */
   logStreamPrefix?: string;
+  /**
+   * Optional sns topic to subscribe all alarms to
+   */
+  snsTopic?: Topic;
 };
 
 export class MeshHosting extends Construct {

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -7,9 +7,12 @@ import { Repository } from "aws-cdk-lib/aws-ecr";
 import { FargateService } from "aws-cdk-lib/aws-ecs";
 import { CfnCacheCluster } from "aws-cdk-lib/aws-elasticache";
 import * as ssm from "aws-cdk-lib/aws-ssm";
-import { AWSManagedRule } from "./web-application-firewall";
+import { AWSManagedRule, WebApplicationFirewall } from "./web-application-firewall";
 import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
 import { ScalingInterval } from "aws-cdk-lib/aws-autoscaling";
+import { Dashboard } from "./dashboard";
+import { ApplicationLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { LogGroup } from "aws-cdk-lib/aws-logs";
 
 export type MeshHostingProps = {
   /**
@@ -114,14 +117,22 @@ export type MeshHostingProps = {
    * Defaults to true
    */
   containerInsights?: boolean;
+  /**
+   * Log stream prefix
+   * Defaults to 'graphql-server'
+   */
+  logStreamPrefix?: string;
 };
 
 export class MeshHosting extends Construct {
   public readonly vpc: IVpc;
   public readonly repository: Repository;
   public readonly service: FargateService;
+  public readonly loadBalancer: ApplicationLoadBalancer;
+  public readonly logGroup: LogGroup;
   public readonly cacheCluster: CfnCacheCluster;
   public readonly securityGroup: SecurityGroup;
+  public readonly firewall: WebApplicationFirewall;
 
   constructor(scope: Construct, id: string, props: MeshHostingProps) {
     super(scope, id);
@@ -153,12 +164,23 @@ export class MeshHosting extends Construct {
     });
 
     this.service = mesh.service;
+    this.firewall = mesh.firewall;
+    this.loadBalancer = mesh.loadBalancer;
+    this.logGroup = mesh.logGroup;
     this.repository = mesh.repository;
 
     new CodePipelineService(this, "pipeline", {
       repository: this.repository,
       service: this.service,
       notificationArn: props.notificationArn,
+    });
+
+    new Dashboard(this, "cloudwatch", {
+      ...props,
+      service: this.service,
+      loadBalancer: this.loadBalancer,
+      logGroup: this.logGroup,
+      firewall: this.firewall,
     });
   }
 }

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -14,6 +14,7 @@ import { PerformanceMetrics } from "./metrics";
 import { ApplicationLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { Topic } from "aws-cdk-lib/aws-sns";
+import { Alarm } from "aws-cdk-lib/aws-cloudwatch";
 
 export type MeshHostingProps = {
   /**
@@ -127,6 +128,10 @@ export type MeshHostingProps = {
    * Optional sns topic to subscribe all alarms to
    */
   snsTopic?: Topic;
+  /**
+   * Any additional custom alarms
+   */
+  additionalAlarms?: Alarm[];
 };
 
 export class MeshHosting extends Construct {

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -7,7 +7,10 @@ import { Repository } from "aws-cdk-lib/aws-ecr";
 import { FargateService } from "aws-cdk-lib/aws-ecs";
 import { CfnCacheCluster } from "aws-cdk-lib/aws-elasticache";
 import * as ssm from "aws-cdk-lib/aws-ssm";
-import { AWSManagedRule, WebApplicationFirewall } from "./web-application-firewall";
+import {
+  AWSManagedRule,
+  WebApplicationFirewall,
+} from "./web-application-firewall";
 import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
 import { ScalingInterval } from "aws-cdk-lib/aws-autoscaling";
 import { PerformanceMetrics } from "./metrics";

--- a/packages/graphql-mesh-server/lib/metrics.ts
+++ b/packages/graphql-mesh-server/lib/metrics.ts
@@ -28,13 +28,14 @@ export interface PerformanceMetricsProps {
   firewall: WebApplicationFirewall;
   logGroup: LogGroup;
   snsTopic?: Topic;
+  additionalAlarms?: Alarm[];
 }
 
 export class PerformanceMetrics extends Construct {
   constructor(scope: Construct, id: string, props: PerformanceMetricsProps) {
     super(scope, id);
 
-    const alarms: Alarm[] = [];
+    const alarms: Alarm[] = props.additionalAlarms || [];
 
     // Load balancer metrics and widgets
     const requestCountMetrics: Metric[] = [

--- a/packages/graphql-mesh-server/lib/metrics.ts
+++ b/packages/graphql-mesh-server/lib/metrics.ts
@@ -5,7 +5,7 @@ import {
   SingleValueWidget,
   GraphWidget,
   LegendPosition,
-  Dashboard as CWDashboard,
+  Dashboard,
   Column,
   LogQueryWidget,
 } from "aws-cdk-lib/aws-cloudwatch";
@@ -18,16 +18,15 @@ import {
 import { WebApplicationFirewall } from "./web-application-firewall";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface DashboardProps {
+export interface PerformanceMetricsProps {
   service: FargateService;
   loadBalancer: ApplicationLoadBalancer;
   firewall: WebApplicationFirewall;
   logGroup: LogGroup;
 }
 
-export class Dashboard extends Construct {
-  constructor(scope: Construct, id: string, props: DashboardProps) {
+export class PerformanceMetrics extends Construct {
+  constructor(scope: Construct, id: string, props: PerformanceMetricsProps) {
     super(scope, id);
 
     // Load balancer metrics and widgets
@@ -258,7 +257,7 @@ export class Dashboard extends Construct {
     });
 
     // Create the dashboard
-    new CWDashboard(this, "dashboard", {
+    new Dashboard(this, "dashboard", {
       dashboardName: "Mesh-Dashboard",
       widgets: [
         [new Column(...loadBalancerWidgets), new Column(...wafWidgets)],

--- a/packages/graphql-mesh-server/lib/metrics.ts
+++ b/packages/graphql-mesh-server/lib/metrics.ts
@@ -108,8 +108,7 @@ export class PerformanceMetrics extends Construct {
         namespace: "AWS/WAFV2",
         metricName: "AllowedRequests",
         dimensionsMap: {
-          WebACL:
-            props.firewall.acl.ref.split('|')[0],
+          WebACL: props.firewall.acl.ref.split("|")[0],
           Rule: "ALL",
           Region: Stack.of(this).region, // assumes waf is in the same region
         },


### PR DESCRIPTION
**Description of the proposed changes**  

Bit of a big one :sweat_smile: All changes are around monitoring of the graphql server. Now by default there are:
- Common alarms (that can optionally notify on an SNS topic)
- A dashboard

Currently no way to customise these alarms but I am worried about the props getting too large. Keen to hear your thoughts on this!

**Screenshots (if applicable)**  

![image](https://github.com/aligent/cdk-constructs/assets/6127662/9d57a76f-0bbe-495d-a2ef-62ee57f719e5)
![image](https://github.com/aligent/cdk-constructs/assets/6127662/267a8a8d-3cb0-4f4e-800b-f73898e5b1be)


**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback