### PR TITLE
Fix imports of experimental cloudfront lambda@edge functions

### DIFF
--- a/packages/basic-auth/lib/basic-auth-construct.ts
+++ b/packages/basic-auth/lib/basic-auth-construct.ts
@@ -1,5 +1,5 @@
 import { Construct } from "constructs";
-import { EdgeFunction } from "aws-cdk-lib/aws-cloudfront/lib/experimental";
+import { experimental } from "aws-cdk-lib/aws-cloudfront";
 import { Esbuild } from "@aligent/cdk-esbuild";
 import { AssetHashType, DockerImage } from "aws-cdk-lib";
 import { Code, IVersion, Runtime, Version } from "aws-cdk-lib/aws-lambda";
@@ -11,7 +11,7 @@ export interface BasicAuthFunctionOptions {
 }
 
 export class BasicAuthFunction extends Construct {
-  readonly edgeFunction: EdgeFunction;
+  readonly edgeFunction: experimental.EdgeFunction;
 
   constructor(scope: Construct, id: string, options: BasicAuthFunctionOptions) {
     super(scope, id);
@@ -22,24 +22,28 @@ export class BasicAuthFunction extends Construct {
       'echo "Docker build not supported. Please install esbuild."',
     ];
 
-    this.edgeFunction = new EdgeFunction(this, `${id}-basic-auth-fn`, {
-      code: Code.fromAsset(join(__dirname, "handlers"), {
-        assetHashType: AssetHashType.OUTPUT,
-        bundling: {
-          command,
-          image: DockerImage.fromRegistry("busybox"),
-          local: new Esbuild({
-            entryPoints: [join(__dirname, "handlers/basic-auth.ts")],
-            define: {
-              "process.env.AUTH_USERNAME": options.username,
-              "process.env.AUTH_PASSWORD": options.password,
-            },
-          }),
-        },
-      }),
-      runtime: Runtime.NODEJS_18_X,
-      handler: "basic-auth.handler",
-    });
+    this.edgeFunction = new experimental.EdgeFunction(
+      this,
+      `${id}-basic-auth-fn`,
+      {
+        code: Code.fromAsset(join(__dirname, "handlers"), {
+          assetHashType: AssetHashType.OUTPUT,
+          bundling: {
+            command,
+            image: DockerImage.fromRegistry("busybox"),
+            local: new Esbuild({
+              entryPoints: [join(__dirname, "handlers/basic-auth.ts")],
+              define: {
+                "process.env.AUTH_USERNAME": options.username,
+                "process.env.AUTH_PASSWORD": options.password,
+              },
+            }),
+          },
+        }),
+        runtime: Runtime.NODEJS_18_X,
+        handler: "basic-auth.handler",
+      }
+    );
   }
 
   public getFunctionVersion(): IVersion {

--- a/packages/cloudfront-security-headers/lib/index.ts
+++ b/packages/cloudfront-security-headers/lib/index.ts
@@ -1,5 +1,5 @@
 import { AssetHashType, DockerImage } from "aws-cdk-lib";
-import { EdgeFunction } from "aws-cdk-lib/aws-cloudfront/lib/experimental";
+import { experimental } from "aws-cdk-lib/aws-cloudfront";
 import { Code, IVersion, Runtime, Version } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { join } from "path";
@@ -10,7 +10,7 @@ export interface SecurityHeaderFunctionProps {
 }
 
 export class SecurityHeaderFunction extends Construct {
-  readonly edgeFunction: EdgeFunction;
+  readonly edgeFunction: experimental.EdgeFunction;
 
   constructor(
     scope: Construct,
@@ -35,21 +35,25 @@ export class SecurityHeaderFunction extends Construct {
       'echo "Docker build not supported. Please install esbuild."',
     ];
 
-    this.edgeFunction = new EdgeFunction(this, `${id}-security-header-fn`, {
-      code: Code.fromAsset(join(__dirname, "handlers"), {
-        assetHashType: AssetHashType.OUTPUT,
-        bundling: {
-          command,
-          image: DockerImage.fromRegistry("busybox"),
-          local: new Esbuild({
-            entryPoints: [join(__dirname, "handlers/security-header.ts")],
-            define: defineOptions,
-          }),
-        },
-      }),
-      runtime: Runtime.NODEJS_18_X,
-      handler: "security-header.handler",
-    });
+    this.edgeFunction = new experimental.EdgeFunction(
+      this,
+      `${id}-security-header-fn`,
+      {
+        code: Code.fromAsset(join(__dirname, "handlers"), {
+          assetHashType: AssetHashType.OUTPUT,
+          bundling: {
+            command,
+            image: DockerImage.fromRegistry("busybox"),
+            local: new Esbuild({
+              entryPoints: [join(__dirname, "handlers/security-header.ts")],
+              define: defineOptions,
+            }),
+          },
+        }),
+        runtime: Runtime.NODEJS_18_X,
+        handler: "security-header.handler",
+      }
+    );
   }
 
   public getFunctionVersion(): IVersion {

--- a/packages/geoip-redirect/lib/redirect-construct.ts
+++ b/packages/geoip-redirect/lib/redirect-construct.ts
@@ -1,5 +1,5 @@
 import { AssetHashType, DockerImage } from "aws-cdk-lib";
-import { EdgeFunction } from "aws-cdk-lib/aws-cloudfront/lib/experimental";
+import { experimental } from "aws-cdk-lib/aws-cloudfront";
 import { Code, IVersion, Runtime, Version } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { join } from "path";
@@ -14,7 +14,7 @@ export interface RedirectFunctionOptions {
 }
 
 export class RedirectFunction extends Construct {
-  readonly edgeFunction: EdgeFunction;
+  readonly edgeFunction: experimental.EdgeFunction;
 
   constructor(scope: Construct, id: string, options: RedirectFunctionOptions) {
     super(scope, id);
@@ -25,26 +25,30 @@ export class RedirectFunction extends Construct {
       'echo "Docker build not supported. Please install esbuild."',
     ];
 
-    this.edgeFunction = new EdgeFunction(this, `${id}-redirect-fn`, {
-      code: Code.fromAsset(join(__dirname, "handlers"), {
-        assetHashType: AssetHashType.OUTPUT,
-        bundling: {
-          command,
-          image: DockerImage.fromRegistry("busybox"),
-          local: new Esbuild({
-            entryPoints: [join(__dirname, "handlers/redirect.ts")],
-            define: {
-              "process.env.REDIRECT_HOST": options.redirectHost,
-              "process.env.SUPPORTED_REGIONS":
-                options.supportedRegionsExpression,
-              "process.env.DEFAULT_REGION": options.defaultRegion,
-            },
-          }),
-        },
-      }),
-      runtime: Runtime.NODEJS_18_X,
-      handler: "redirect.handler",
-    });
+    this.edgeFunction = new experimental.EdgeFunction(
+      this,
+      `${id}-redirect-fn`,
+      {
+        code: Code.fromAsset(join(__dirname, "handlers"), {
+          assetHashType: AssetHashType.OUTPUT,
+          bundling: {
+            command,
+            image: DockerImage.fromRegistry("busybox"),
+            local: new Esbuild({
+              entryPoints: [join(__dirname, "handlers/redirect.ts")],
+              define: {
+                "process.env.REDIRECT_HOST": options.redirectHost,
+                "process.env.SUPPORTED_REGIONS":
+                  options.supportedRegionsExpression,
+                "process.env.DEFAULT_REGION": options.defaultRegion,
+              },
+            }),
+          },
+        }),
+        runtime: Runtime.NODEJS_18_X,
+        handler: "redirect.handler",
+      }
+    );
   }
 
   public getFunctionVersion(): IVersion {

--- a/packages/prerender-proxy/lib/error-response-construct.ts
+++ b/packages/prerender-proxy/lib/error-response-construct.ts
@@ -1,5 +1,5 @@
 import { AssetHashType, DockerImage } from "aws-cdk-lib";
-import { EdgeFunction } from "aws-cdk-lib/aws-cloudfront/lib/experimental";
+import { experimental } from "aws-cdk-lib/aws-cloudfront";
 import { Code, IVersion, Runtime, Version } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { join } from "path";
@@ -10,7 +10,7 @@ export interface ErrorResponseFunctionOptions {
 }
 
 export class ErrorResponseFunction extends Construct {
-  readonly edgeFunction: EdgeFunction;
+  readonly edgeFunction: experimental.EdgeFunction;
 
   constructor(
     scope: Construct,
@@ -25,23 +25,27 @@ export class ErrorResponseFunction extends Construct {
       'echo "Docker build not supported. Please install esbuild."',
     ];
 
-    this.edgeFunction = new EdgeFunction(this, `${id}-error-response-fn`, {
-      code: Code.fromAsset(join(__dirname, "handlers"), {
-        assetHashType: AssetHashType.OUTPUT,
-        bundling: {
-          command,
-          image: DockerImage.fromRegistry("busybox"),
-          local: new Esbuild({
-            entryPoints: [join(__dirname, "handlers/error-response.ts")],
-            define: {
-              "process.env.PATH_PREFIX": options.pathPrefix ?? "",
-            },
-          }),
-        },
-      }),
-      runtime: Runtime.NODEJS_18_X,
-      handler: "error-response.handler",
-    });
+    this.edgeFunction = new experimental.EdgeFunction(
+      this,
+      `${id}-error-response-fn`,
+      {
+        code: Code.fromAsset(join(__dirname, "handlers"), {
+          assetHashType: AssetHashType.OUTPUT,
+          bundling: {
+            command,
+            image: DockerImage.fromRegistry("busybox"),
+            local: new Esbuild({
+              entryPoints: [join(__dirname, "handlers/error-response.ts")],
+              define: {
+                "process.env.PATH_PREFIX": options.pathPrefix ?? "",
+              },
+            }),
+          },
+        }),
+        runtime: Runtime.NODEJS_18_X,
+        handler: "error-response.handler",
+      }
+    );
   }
 
   public getFunctionVersion(): IVersion {

--- a/packages/prerender-proxy/lib/prerender-cf-cache-control-construct.ts
+++ b/packages/prerender-proxy/lib/prerender-cf-cache-control-construct.ts
@@ -1,5 +1,5 @@
 import { AssetHashType, DockerImage } from "aws-cdk-lib";
-import { EdgeFunction } from "aws-cdk-lib/aws-cloudfront/lib/experimental";
+import { experimental } from "aws-cdk-lib/aws-cloudfront";
 import { Code, IVersion, Runtime, Version } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { join } from "path";
@@ -11,7 +11,7 @@ export interface CloudFrontCacheControlOptions {
 }
 
 export class CloudFrontCacheControl extends Construct {
-  readonly edgeFunction: EdgeFunction;
+  readonly edgeFunction: experimental.EdgeFunction;
 
   constructor(
     scope: Construct,
@@ -26,26 +26,30 @@ export class CloudFrontCacheControl extends Construct {
       'echo "Docker build not supported. Please install esbuild."',
     ];
 
-    this.edgeFunction = new EdgeFunction(this, `${id}-cache-control-fn`, {
-      code: Code.fromAsset(join(__dirname, "handlers"), {
-        assetHashType: AssetHashType.OUTPUT,
-        bundling: {
-          command,
-          image: DockerImage.fromRegistry("busybox"),
-          local: new Esbuild({
-            entryPoints: [join(__dirname, "handlers/cache-control.ts")],
-            define: {
-              "process.env.PRERENDER_CACHE_KEY":
-                options?.cacheKey ?? "x-prerender-requestid",
-              "process.env.PRERENDER_CACHE_MAX_AGE":
-                String(options?.maxAge) ?? "0",
-            },
-          }),
-        },
-      }),
-      runtime: Runtime.NODEJS_18_X,
-      handler: "cache-control.handler",
-    });
+    this.edgeFunction = new experimental.EdgeFunction(
+      this,
+      `${id}-cache-control-fn`,
+      {
+        code: Code.fromAsset(join(__dirname, "handlers"), {
+          assetHashType: AssetHashType.OUTPUT,
+          bundling: {
+            command,
+            image: DockerImage.fromRegistry("busybox"),
+            local: new Esbuild({
+              entryPoints: [join(__dirname, "handlers/cache-control.ts")],
+              define: {
+                "process.env.PRERENDER_CACHE_KEY":
+                  options?.cacheKey ?? "x-prerender-requestid",
+                "process.env.PRERENDER_CACHE_MAX_AGE":
+                  String(options?.maxAge) ?? "0",
+              },
+            }),
+          },
+        }),
+        runtime: Runtime.NODEJS_18_X,
+        handler: "cache-control.handler",
+      }
+    );
   }
 
   public getFunctionVersion(): IVersion {

--- a/packages/prerender-proxy/lib/prerender-check-construct.ts
+++ b/packages/prerender-proxy/lib/prerender-check-construct.ts
@@ -1,12 +1,12 @@
 import { AssetHashType, DockerImage } from "aws-cdk-lib";
-import { EdgeFunction } from "aws-cdk-lib/aws-cloudfront/lib/experimental";
+import { experimental } from "aws-cdk-lib/aws-cloudfront";
 import { Code, IVersion, Runtime, Version } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { join } from "path";
 import { Esbuild } from "@aligent/cdk-esbuild";
 
 export class PrerenderCheckFunction extends Construct {
-  readonly edgeFunction: EdgeFunction;
+  readonly edgeFunction: experimental.EdgeFunction;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -17,20 +17,24 @@ export class PrerenderCheckFunction extends Construct {
       'echo "Docker build not supported. Please install esbuild."',
     ];
 
-    this.edgeFunction = new EdgeFunction(this, `${id}-prerender-check-fn`, {
-      code: Code.fromAsset(join(__dirname, "handlers"), {
-        assetHashType: AssetHashType.OUTPUT,
-        bundling: {
-          command,
-          image: DockerImage.fromRegistry("busybox"),
-          local: new Esbuild({
-            entryPoints: [join(__dirname, "handlers/prerender-check.ts")],
-          }),
-        },
-      }),
-      runtime: Runtime.NODEJS_18_X,
-      handler: "prerender-check.handler",
-    });
+    this.edgeFunction = new experimental.EdgeFunction(
+      this,
+      `${id}-prerender-check-fn`,
+      {
+        code: Code.fromAsset(join(__dirname, "handlers"), {
+          assetHashType: AssetHashType.OUTPUT,
+          bundling: {
+            command,
+            image: DockerImage.fromRegistry("busybox"),
+            local: new Esbuild({
+              entryPoints: [join(__dirname, "handlers/prerender-check.ts")],
+            }),
+          },
+        }),
+        runtime: Runtime.NODEJS_18_X,
+        handler: "prerender-check.handler",
+      }
+    );
   }
 
   public getFunctionVersion(): IVersion {

--- a/packages/prerender-proxy/lib/prerender-construct.ts
+++ b/packages/prerender-proxy/lib/prerender-construct.ts
@@ -1,5 +1,5 @@
 import { AssetHashType, DockerImage } from "aws-cdk-lib";
-import { EdgeFunction } from "aws-cdk-lib/aws-cloudfront/lib/experimental";
+import { experimental } from "aws-cdk-lib/aws-cloudfront";
 import { Code, IVersion, Runtime, Version } from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import { join } from "path";
@@ -12,7 +12,7 @@ export interface PrerenderFunctionOptions {
 }
 
 export class PrerenderFunction extends Construct {
-  readonly edgeFunction: EdgeFunction;
+  readonly edgeFunction: experimental.EdgeFunction;
 
   constructor(scope: Construct, id: string, options: PrerenderFunctionOptions) {
     super(scope, id);
@@ -23,26 +23,30 @@ export class PrerenderFunction extends Construct {
       'echo "Docker build not supported. Please install esbuild."',
     ];
 
-    this.edgeFunction = new EdgeFunction(this, `${id}-prerender-fn`, {
-      code: Code.fromAsset(join(__dirname, "handlers"), {
-        assetHashType: AssetHashType.OUTPUT,
-        bundling: {
-          command,
-          image: DockerImage.fromRegistry("busybox"),
-          local: new Esbuild({
-            entryPoints: [join(__dirname, "handlers/prerender.ts")],
-            define: {
-              "process.env.PRERENDER_TOKEN": options.prerenderToken,
-              "process.env.PATH_PREFIX": options.pathPrefix ?? "",
-              "process.env.PRERENDER_URL":
-                options.prerenderUrl ?? "service.prerender.io",
-            },
-          }),
-        },
-      }),
-      runtime: Runtime.NODEJS_18_X,
-      handler: "prerender.handler",
-    });
+    this.edgeFunction = new experimental.EdgeFunction(
+      this,
+      `${id}-prerender-fn`,
+      {
+        code: Code.fromAsset(join(__dirname, "handlers"), {
+          assetHashType: AssetHashType.OUTPUT,
+          bundling: {
+            command,
+            image: DockerImage.fromRegistry("busybox"),
+            local: new Esbuild({
+              entryPoints: [join(__dirname, "handlers/prerender.ts")],
+              define: {
+                "process.env.PRERENDER_TOKEN": options.prerenderToken,
+                "process.env.PATH_PREFIX": options.pathPrefix ?? "",
+                "process.env.PRERENDER_URL":
+                  options.prerenderUrl ?? "service.prerender.io",
+              },
+            }),
+          },
+        }),
+        runtime: Runtime.NODEJS_18_X,
+        handler: "prerender.handler",
+      }
+    );
   }
 
   public getFunctionVersion(): IVersion {


### PR DESCRIPTION
**Description of the proposed changes**  
Fix the imports of experimental cloudfront edge functions.

Ref: https://github.com/aws/aws-cdk/issues/18163#issuecomment-1002714184

Error:
```
npx cdk synth 'Staging/*' 
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './aws-cloudfront/lib/experimental' is not defined by "exports" in node_modules/aws-cdk-lib/package.json
    at new NodeError (node:internal/errors:405:5)
    at exportsNotFound (node:internal/modules/esm/resolve:362:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:698:9)
    at resolveExports (node:internal/modules/cjs/loader:567:36)
    at Function.Module._findPath (node:internal/modules/cjs/loader:636:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1063:27)
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (node_modules/@cspotcode/source-map-support/source-map-support.js:811:30)
    at Function.Module._load (node:internal/modules/cjs/loader:922:27)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:119:18) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}

Subprocess exited with error 1

```

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback