### PR TITLE
Make region in AWS Lambda configurable for cross-region notifications

### DIFF
--- a/packages/graphql-mesh-server/assets/handlers/notify-sns.ts
+++ b/packages/graphql-mesh-server/assets/handlers/notify-sns.ts
@@ -1,7 +1,7 @@
 import { PublishCommand, SNSClient } from "@aws-sdk/client-sns";
 import { SNSEvent } from "aws-lambda";
 
-const client = new SNSClient({ region: process.env.AWS_REGION });
+const client = new SNSClient({ region: process.env.REGION });
 
 export const handler = async (event: SNSEvent): Promise<void> => {
   const record = event.Records[0];

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -82,6 +82,10 @@ export type MeshHostingProps = {
    */
   notificationArn?: string;
   /**
+   * Region of the SNS Topic that deployment notifications are sent to
+   */
+  notificationRegion?: string;
+  /**
    * List of IPv4 addresses to block
    */
   blockedIps?: string[];
@@ -186,6 +190,7 @@ export class MeshHosting extends Construct {
       repository: this.repository,
       service: this.service,
       notificationArn: props.notificationArn,
+      notificationRegion: props.notificationRegion,
     });
 
     new PerformanceMetrics(this, "cloudwatch", {

--- a/packages/graphql-mesh-server/lib/pipeline.ts
+++ b/packages/graphql-mesh-server/lib/pipeline.ts
@@ -1,4 +1,4 @@
-import { Duration } from "aws-cdk-lib";
+import { Duration, Stack } from "aws-cdk-lib";
 import { Artifact, Pipeline } from "aws-cdk-lib/aws-codepipeline";
 import { Repository } from "aws-cdk-lib/aws-ecr";
 import { FargateService } from "aws-cdk-lib/aws-ecs";
@@ -38,6 +38,11 @@ export interface CodePipelineServiceProps {
    * ARN of the SNS Topic to send deployment notifications to
    */
   notificationArn?: string;
+
+  /**
+   * AWS Region the SNS topic is deployed in
+   */
+  notificationRegion?: string;
 }
 
 export class CodePipelineService extends Construct {
@@ -115,6 +120,7 @@ export class CodePipelineService extends Construct {
         timeout: Duration.seconds(10),
         environment: {
           SNS_TOPIC: props.notificationArn,
+          REGION: props.notificationRegion || Stack.of(this).region,
         },
       });
 


### PR DESCRIPTION
**Description of the proposed changes**  
Allow the region to be configured via props (default to the region the stack is deployed in), so that the lambda can use the destination region when the stack is deployed in another region.

e.g. when deployed the SNS topic exists in AP-SOUTHEAST-2 and the lambda is deployed in US-EAST-1 the client should be configured to use AP-SOUTHEAST-2. 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback