### PR TITLE
Prerender cdk v2 hotfixes

### DIFF
--- a/packages/prerender-fargate/lib/prerender-fargate-options.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate-options.ts
@@ -1,4 +1,5 @@
 import { PrerenderTokenUrlAssociationOptions } from "./recaching/prerender-tokens";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
 
 /**
  * Options for configuring the Prerender Fargate construct.
@@ -15,8 +16,14 @@ export interface PrerenderFargateOptions {
   /**
    * The ID of the VPC to deploy the Fargate service in.
    * @default - The default VPC will be used
+   * @deprecated Use vpc instead and perform the lookup outside of the construct if needed.
    */
   vpcId?: string;
+  /**
+   * The VPC to deploy the Fargate service in.
+   * @default - The default VPC will be used
+   */
+  vpc?: ec2.IVpc;
   /**
    * The name of the S3 bucket to store prerendered pages in.
    */

--- a/packages/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate.ts
@@ -40,7 +40,7 @@ import { PrerenderFargateOptions } from "./prerender-fargate-options";
  *     prerenderName: 'myPrerender',
  *     bucketName: 'myPrerenderBucket',
  *     expirationDays: 7,
- *     vpcId: 'vpc-xxxxxxxx',
+ *     vpc: vpc,
  *     desiredInstanceCount: 1,
  *     instanceCPU: 512,
  *     instanceMemory: 1024,
@@ -87,7 +87,6 @@ export class PrerenderFargate extends Construct {
     const {
       tokenUrlAssociation,
       certificateArn,
-      vpcId,
       maxInstanceCount,
       instanceMemory,
       instanceCPU,
@@ -117,8 +116,15 @@ export class PrerenderFargate extends Construct {
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
     });
 
-    const vpcLookup = vpcId ? { vpcId: vpcId } : { isDefault: true };
-    const vpc = ec2.Vpc.fromLookup(this, "vpc", vpcLookup);
+    // If a VPC is not provided then deploy to the default VPC
+    let vpc: ec2.IVpc;
+    if (props.vpc) {
+      vpc = props.vpc;
+    } else if (props.vpcId) {
+      vpc = ec2.Vpc.fromLookup(this, "vpc", { vpcId: props.vpcId });
+    } else {
+      vpc = ec2.Vpc.fromLookup(this, "vpc", { isDefault: true });
+    }
 
     const cluster = new ecs.Cluster(this, `${prerenderName}-cluster`, {
       vpc: vpc,

--- a/packages/prerender-proxy/lib/error-response-construct.ts
+++ b/packages/prerender-proxy/lib/error-response-construct.ts
@@ -7,6 +7,7 @@ import { Esbuild } from "@aligent/cdk-esbuild";
 
 export interface ErrorResponseFunctionOptions {
   pathPrefix?: string;
+  frontendHost: string;
 }
 
 export class ErrorResponseFunction extends Construct {
@@ -37,7 +38,12 @@ export class ErrorResponseFunction extends Construct {
             local: new Esbuild({
               entryPoints: [join(__dirname, "handlers/error-response.ts")],
               define: {
-                "process.env.PATH_PREFIX": options.pathPrefix ?? "",
+                "process.env.PATH_PREFIX": JSON.stringify(
+                  options.pathPrefix ?? ""
+                ),
+                "process.env.FRONTEND_HOST": JSON.stringify(
+                  options.frontendHost
+                ),
               },
             }),
           },

--- a/packages/prerender-proxy/lib/prerender-cf-cache-control-construct.ts
+++ b/packages/prerender-proxy/lib/prerender-cf-cache-control-construct.ts
@@ -38,10 +38,12 @@ export class CloudFrontCacheControl extends Construct {
             local: new Esbuild({
               entryPoints: [join(__dirname, "handlers/cache-control.ts")],
               define: {
-                "process.env.PRERENDER_CACHE_KEY":
-                  options?.cacheKey ?? "x-prerender-requestid",
-                "process.env.PRERENDER_CACHE_MAX_AGE":
-                  String(options?.maxAge) ?? "0",
+                "process.env.PRERENDER_CACHE_KEY": JSON.stringify(
+                  options?.cacheKey ?? "x-prerender-requestid"
+                ),
+                "process.env.PRERENDER_CACHE_MAX_AGE": JSON.stringify(
+                  String(options?.maxAge) ?? "0"
+                ),
               },
             }),
           },

--- a/packages/prerender-proxy/lib/prerender-construct.ts
+++ b/packages/prerender-proxy/lib/prerender-construct.ts
@@ -35,10 +35,15 @@ export class PrerenderFunction extends Construct {
             local: new Esbuild({
               entryPoints: [join(__dirname, "handlers/prerender.ts")],
               define: {
-                "process.env.PRERENDER_TOKEN": options.prerenderToken,
-                "process.env.PATH_PREFIX": options.pathPrefix ?? "",
-                "process.env.PRERENDER_URL":
-                  options.prerenderUrl ?? "service.prerender.io",
+                "process.env.PRERENDER_TOKEN": JSON.stringify(
+                  options.prerenderToken
+                ),
+                "process.env.PATH_PREFIX": JSON.stringify(
+                  options.pathPrefix ?? ""
+                ),
+                "process.env.PRERENDER_URL": JSON.stringify(
+                  options.prerenderUrl ?? "service.prerender.io"
+                ),
               },
             }),
           },

--- a/packages/prerender-proxy/lib/prerender-lambda-construct.ts
+++ b/packages/prerender-proxy/lib/prerender-lambda-construct.ts
@@ -4,12 +4,18 @@ import {
   CloudFrontCacheControlOptions,
 } from "./prerender-cf-cache-control-construct";
 import { PrerenderCheckFunction } from "./prerender-check-construct";
-import { PrerenderFunction } from "./prerender-construct";
-import { ErrorResponseFunction } from "./error-response-construct";
+import {
+  PrerenderFunction,
+  PrerenderFunctionOptions,
+} from "./prerender-construct";
+import {
+  ErrorResponseFunction,
+  ErrorResponseFunctionOptions,
+} from "./error-response-construct";
 
 export interface PrerenderLambdaProps {
-  prerenderToken: string;
-  exclusionExpression?: string;
+  prerenderProps: PrerenderFunctionOptions;
+  errorResponseProps: ErrorResponseFunctionOptions;
   cacheControlProps?: CloudFrontCacheControlOptions;
 }
 
@@ -30,13 +36,13 @@ export class PrerenderLambda extends Construct {
     this.prerenderFunction = new PrerenderFunction(
       this,
       "PrerenderOriginRequest",
-      props
+      props.prerenderProps
     );
 
     this.errorResponseFunction = new ErrorResponseFunction(
       this,
       "ErrorResponse",
-      {}
+      props.errorResponseProps
     );
 
     this.cacheControlFunction = new CloudFrontCacheControl(


### PR DESCRIPTION
**Description of the proposed changes**  
This PR fixes a couple of issues:

1. Unable to passthrough required props to Lambda functions when using the  `PrerenderLambda` construct
2. Esbuild fails for lambda functions due to not being wrapped in json.stringify
3. Cannot use a real VPC object when passing to the `PrerenderFargate` construct as all references to the vpcId MUST be a string and cannot be a ref

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback