### PR TITLE
HOTFIX: Fix Prerender proxy lambda@edge

### DIFF
--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -108,9 +108,13 @@ export interface StaticHostingProps {
   overrideLogicalId?: string;
 
   /**
-   *
+   * A Request policy used on the default behavior
    */
   defaultBehaviorRequestPolicy?: OriginRequestPolicy;
+
+  /**
+   * A Cache policy used on the default behavior
+   */
   defaultBehaviorCachePolicy?: CachePolicy;
 }
 

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -106,6 +106,12 @@ export interface StaticHostingProps {
    * https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudfront-readme.html#migrating-from-the-original-cloudfrontwebdistribution-to-the-newer-distribution-construct.
    */
   overrideLogicalId?: string;
+
+  /**
+   *
+   */
+  defaultBehaviorRequestPolicy?: OriginRequestPolicy;
+  defaultBehaviorCachePolicy?: CachePolicy;
 }
 
 interface remapPath {
@@ -255,20 +261,20 @@ export class StaticHosting extends Construct {
     });
     let backendOrigin = undefined;
 
-    const originRequestPolicy = new OriginRequestPolicy(
-      this,
-      "S3OriginRequestPolicy",
-      {
+    const originRequestPolicy =
+      props.defaultBehaviorRequestPolicy ||
+      new OriginRequestPolicy(this, "S3OriginRequestPolicy", {
         headerBehavior:
           OriginRequestHeaderBehavior.allowList("x-forwarded-host"),
-      }
-    );
+      });
 
-    const originCachePolicy = new CachePolicy(this, "S3OriginCachePolicy", {
-      headerBehavior: CacheHeaderBehavior.allowList("x-forwarded-host"),
-      enableAcceptEncodingBrotli: true,
-      enableAcceptEncodingGzip: true,
-    });
+    const originCachePolicy =
+      props.defaultBehaviorCachePolicy ||
+      new CachePolicy(this, "S3OriginCachePolicy", {
+        headerBehavior: CacheHeaderBehavior.allowList("x-forwarded-host"),
+        enableAcceptEncodingBrotli: true,
+        enableAcceptEncodingGzip: true,
+      });
 
     const errorResponses: ErrorResponse[] = [
       {


### PR DESCRIPTION
------

**Description of the proposed changes**  

This PR allows passing through a request and cache policy so that prerender headers can be added to the allowlist. Otherwise the prerender headers are not passed to the origin request lambda@edge function and the origin switch to prerender is not performed.

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback