### PR TITLE
DO-1608: use most recent cipher suite for CloudFront distribution security policy

### DIFF
--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -386,7 +386,7 @@ export class StaticHosting extends Construct {
       logBucket: props.enableCloudFrontAccessLogging
         ? loggingBucket
         : undefined,
-      minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2_2018,
+      minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2_2021,
       certificate: Certificate.fromCertificateArn(
         this,
         "DomainCertificate",


### PR DESCRIPTION

**Description of the proposed changes**  

* Get rid of SSL/TLS ciphers that do not offer forward secrecy (FS) also known as perfect forward secrecy (PFS). 
It's a feature that provides assurances the session keys will not be compromised even if server's private key is compromised.

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback