### PR TITLE
DO-1621: Prerender Proxy - Mark Schema user agent as a bot

### DIFF
--- a/packages/lambda-at-edge-handlers/lib/prerender-check.ts
+++ b/packages/lambda-at-edge-handlers/lib/prerender-check.ts
@@ -2,7 +2,7 @@ import "source-map-support/register";
 import { CloudFrontRequest, CloudFrontRequestEvent } from "aws-lambda";
 
 const IS_BOT =
-  /googlebot|Google-InspectionTool|chrome-lighthouse|lighthouse|adsbot-google|Feedfetcher-Google|bingbot|yandex|baiduspider|Facebot|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator/i;
+  /googlebot|Google-InspectionTool|Schema-Markup-Validator|SchemaBot|chrome-lighthouse|lighthouse|adsbot-google|Feedfetcher-Google|bingbot|yandex|baiduspider|Facebot|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator/i;
 const IS_FILE =
   /\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|svg|eot)$/i;
 

--- a/packages/prerender-proxy/lib/handlers/prerender-check.ts
+++ b/packages/prerender-proxy/lib/handlers/prerender-check.ts
@@ -2,7 +2,7 @@ import "source-map-support/register";
 import { CloudFrontRequest, CloudFrontRequestEvent } from "aws-lambda";
 
 const IS_BOT =
-  /googlebot|Google-InspectionTool|chrome-lighthouse|lighthouse|adsbot-google|Feedfetcher-Google|bingbot|yandex|baiduspider|Facebot|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator/i;
+  /googlebot|Google-InspectionTool|Schema-Markup-Validator|SchemaBot|chrome-lighthouse|lighthouse|adsbot-google|Feedfetcher-Google|bingbot|yandex|baiduspider|Facebot|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator/i;
 const IS_FILE =
   /\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|svg|eot)$/i;
 


### PR DESCRIPTION
<!-- ⚠⚠ Please fill in as many sections as possible  -->
<!-- ⚠⚠ Sections that aren't applicable can be removed, or have "N/A" added under the heading --> 
<!-- ⚠⚠ Please remove leading underscores before filling in. They're only there to force Bitbucket to add a new line underneath each section --> 
<!-- ⚠⚠ This top section should be removed before clicking the Create Pull Request button -->

------

**Description of the proposed changes**  

* DO-1621: Prerender Proxy - Mark Schema user agent as a bot

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  
* Note that this is a must if you are using the GeoIP redirect function, as only Bots are excluded from the logic.
* We might need to bring the same change to CDK V2


🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback