### PR TITLE
feat: add lambda to pipe to invalidate cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -215,6 +215,496 @@
         "tslib": "^1.11.1"
       }
     },
+    "node_modules/@aws-sdk/client-cloudfront": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.515.0.tgz",
+      "integrity": "sha512-aDiTeB2QEX6M9I3yqchCce4z78wRuDOh3oZq2eiBueJqk3R3RGm8zDdsiJ+U9N6NVSmcm7Xs55Ws8NUJZGwizw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/credential-provider-node": "3.515.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@aws-sdk/xml-builder": "3.496.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-stream": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "@smithy/util-waiter": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/client-sso": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.515.0.tgz",
+      "integrity": "sha512-4oGBLW476zmkdN98lAns3bObRNO+DLOfg4MDUSR6l6GYBV/zGAtoy2O/FhwYKgA2L5h2ZtElGopLlk/1Q0ePLw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.515.0.tgz",
+      "integrity": "sha512-zACa8LNlPUdlNUBqQRf5a3MfouLNtcBfm84v2c8M976DwJrMGONPe1QjyLLsD38uESQiXiVQRruj/b000iMXNw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.515.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/client-sts": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.515.0.tgz",
+      "integrity": "sha512-ScYuvaIDgip3atOJIA1FU2n0gJkEdveu1KrrCPathoUCV5zpK8qQmO/n+Fj/7hKFxeKdFbB+4W4CsJWYH94nlg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.513.0",
+        "@aws-sdk/middleware-host-header": "3.515.0",
+        "@aws-sdk/middleware-logger": "3.515.0",
+        "@aws-sdk/middleware-recursion-detection": "3.515.0",
+        "@aws-sdk/middleware-user-agent": "3.515.0",
+        "@aws-sdk/region-config-resolver": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@aws-sdk/util-user-agent-browser": "3.515.0",
+        "@aws-sdk/util-user-agent-node": "3.515.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/core": "^1.3.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/hash-node": "^2.1.1",
+        "@smithy/invalid-dependency": "^2.1.1",
+        "@smithy/middleware-content-length": "^2.1.1",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.1",
+        "@smithy/util-defaults-mode-node": "^2.2.0",
+        "@smithy/util-endpoints": "^1.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.515.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/core": {
+      "version": "3.513.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.513.0.tgz",
+      "integrity": "sha512-L+9DL4apWuqNKVOMJ8siAuWoRM9rZf9w1iPv8S2o83WO2jVK7E/m+rNW1dFo9HsA5V1ccDl2H2qLXx24HiHmOw==",
+      "dependencies": {
+        "@smithy/core": "^1.3.2",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/signature-v4": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.515.0.tgz",
+      "integrity": "sha512-45vxdyqhTAaUMERYVWOziG3K8L2TV9G4ryQS/KZ84o7NAybE9GMdoZRVmGHAO7mJJ1wQiYCM/E+i5b3NW9JfNA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.515.0.tgz",
+      "integrity": "sha512-ouDlNZdv2TKeVEA/YZk2+XklTXyAAGdbWnl4IgN9ItaodWI+lZjdIoNC8BAooVH+atIV/cZgoGTGQL7j2TxJ9A==",
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/credential-provider-env": "3.515.0",
+        "@aws-sdk/credential-provider-process": "3.515.0",
+        "@aws-sdk/credential-provider-sso": "3.515.0",
+        "@aws-sdk/credential-provider-web-identity": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.515.0.tgz",
+      "integrity": "sha512-Y4kHSpbxksiCZZNcvsiKUd8Fb2XlyUuONEwqWFNL82ZH6TCCjBGS31wJQCSxBHqYcOL3tiORUEJkoO7uS30uQA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.515.0",
+        "@aws-sdk/credential-provider-http": "3.515.0",
+        "@aws-sdk/credential-provider-ini": "3.515.0",
+        "@aws-sdk/credential-provider-process": "3.515.0",
+        "@aws-sdk/credential-provider-sso": "3.515.0",
+        "@aws-sdk/credential-provider-web-identity": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.515.0.tgz",
+      "integrity": "sha512-pSjiOA2FM63LHRKNDvEpBRp80FVGT0Mw/gzgbqFXP+sewk0WVonYbEcMDTJptH3VsLPGzqH/DQ1YL/aEIBuXFQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.515.0.tgz",
+      "integrity": "sha512-j7vUkiSmuhpBvZYoPTRTI4ePnQbiZMFl6TNhg9b9DprC1zHkucsZnhRhqjOVlrw/H6J4jmcPGcHHTZ5WQNI5xQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.515.0",
+        "@aws-sdk/token-providers": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.515.0.tgz",
+      "integrity": "sha512-66+2g4z3fWwdoGReY8aUHvm6JrKZMTRxjuizljVmMyOBttKPeBYXvUTop/g3ZGUx1f8j+C5qsGK52viYBvtjuQ==",
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.515.0.tgz",
+      "integrity": "sha512-I1MwWPzdRKM1luvdDdjdGsDjNVPhj9zaIytEchjTY40NcKOg+p2evLD2y69ozzg8pyXK63r8DdvDGOo9QPuh0A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.515.0.tgz",
+      "integrity": "sha512-qXomJzg2m/5seQOxHi/yOXOKfSjwrrJSmEmfwJKJyQgdMbBcjz3Cz0H/1LyC6c5hHm6a/SZgSTzDAbAoUmyL+Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.515.0.tgz",
+      "integrity": "sha512-dokHLbTV3IHRIBrw9mGoxcNTnQsjlm7TpkJhPdGT9T4Mq399EyQo51u6IsVMm07RXLl2Zw7u+u9p+qWBFzmFRA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.515.0.tgz",
+      "integrity": "sha512-nOqZjGA/GkjuJ5fUshec9Fv6HFd7ovOTxMJbw3MfAhqXuVZ6dKF41lpVJ4imNsgyFt3shUg9WDY8zGFjlYMB3g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@aws-sdk/util-endpoints": "3.515.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.515.0.tgz",
+      "integrity": "sha512-RIRx9loxMgEAc/r1wPfnfShOuzn4RBi8pPPv6/jhhITEeMnJe6enAh2k5y9DdiVDDgCWZgVFSv0YkAIfzAFsnQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/token-providers": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.515.0.tgz",
+      "integrity": "sha512-MQuf04rIcTXqwDzmyHSpFPF1fKEzRl64oXtCRUF3ddxTdK6wxXkePfK6wNCuL+GEbEcJAoCtIGIRpzGPJvQjHA==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.515.0",
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/types": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.515.0.tgz",
+      "integrity": "sha512-B3gUpiMlpT6ERaLvZZ61D0RyrQPsFYDkCncLPVkZOKkCOoFU46zi1o6T5JcYiz8vkx1q9RGloQ5exh79s5pU/w==",
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.515.0.tgz",
+      "integrity": "sha512-UJi+jdwcGFV/F7d3+e2aQn5yZOVpDiAgfgNhPnEtgV0WozJ5/ZUeZBgWvSc/K415N4A4D/9cbBc7+I+35qzcDQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-endpoints": "^1.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.515.0.tgz",
+      "integrity": "sha512-pTWQb0JCafTmLHLDv3Qqs/nAAJghcPdGQIBpsCStb0YEzg3At/dOi2AIQ683yYnXmeOxLXJDzmlsovfVObJScw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/types": "^2.9.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.515.0.tgz",
+      "integrity": "sha512-A/KJ+/HTohHyVXLH+t/bO0Z2mPrQgELbQO8tX+B2nElo8uklj70r5cT7F8ETsI9oOy+HDVpiL5/v45ZgpUOiPg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.496.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.496.0.tgz",
+      "integrity": "sha512-GvEjh537IIeOw1ZkZuB37sV12u+ipS5Z1dwjEC/HAvhl5ac23ULtTr1/n+U1gLNN+BAKSWjKiQ2ksj8DiUzeyw==",
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudfront/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.478.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.478.0.tgz",
@@ -1963,6 +2453,42 @@
     "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
       "version": "2.6.2",
       "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.515.0.tgz",
+      "integrity": "sha512-Ba6FXK77vU4WyheiamNjEuTFmir0eAXuJGPO27lBaA8g+V/seXGHScsbOG14aQGDOr2P02OPwKGZrWWA7BFpfQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.515.0",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.515.0.tgz",
+      "integrity": "sha512-B3gUpiMlpT6ERaLvZZ61D0RyrQPsFYDkCncLPVkZOKkCOoFU46zi1o6T5JcYiz8vkx1q9RGloQ5exh79s5pU/w==",
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.478.0",
@@ -4372,10 +4898,11 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.15",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4384,7 +4911,8 @@
     },
     "node_modules/@smithy/abort-controller/node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "2.0.0",
@@ -4414,13 +4942,14 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.21",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4432,17 +4961,17 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-l8R89X7+hlt2FEFg+OrNq29LP3h9DfGPmO6ObwT9IXWHD6V7ycpj5u2rVQyIis26ovrgOYakl6nfgmPMm8m1IQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.2.tgz",
+      "integrity": "sha512-tYDmTp0f2TZVE18jAOH1PnmkngLQ+dOGUlMd1u67s87ieueNeyqhja6z/Z4MxhybEiXKOWFOmGjfTZWFxljwJw==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.2.3",
-        "@smithy/middleware-retry": "^2.0.24",
-        "@smithy/middleware-serde": "^2.0.15",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/smithy-client": "^2.1.18",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-retry": "^2.1.1",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4454,13 +4983,14 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.1.4",
-      "license": "Apache-2.0",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/types": "^2.7.0",
-        "@smithy/url-parser": "^2.0.15",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4472,13 +5002,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.15.tgz",
-      "integrity": "sha512-crjvz3j1gGPwA0us6cwS7+5gAn35CTmqu/oIxVbYJo2Qm/sGAye6zGJnMDk3BKhWZw5kcU1G4MxciTkuBpOZPg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -4558,13 +5088,14 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.3.1",
-      "license": "Apache-2.0",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/querystring-builder": "^2.0.15",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-base64": "^2.0.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
@@ -4589,12 +5120,13 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.17",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4624,10 +5156,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.15",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
@@ -4636,8 +5169,9 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -4664,11 +5198,12 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.17",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/types": "^2.7.0",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4680,15 +5215,16 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.2.3",
-      "license": "Apache-2.0",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.15",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/shared-ini-file-loader": "^2.2.7",
-        "@smithy/types": "^2.7.0",
-        "@smithy/url-parser": "^2.0.15",
-        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/middleware-serde": "^2.1.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/url-parser": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4700,16 +5236,17 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.24",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/service-error-classification": "^2.0.8",
-        "@smithy/smithy-client": "^2.1.18",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-middleware": "^2.0.8",
-        "@smithy/util-retry": "^2.0.8",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-retry": "^2.1.1",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -4722,10 +5259,11 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.15",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4737,10 +5275,11 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.9",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4752,12 +5291,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.8",
-      "license": "Apache-2.0",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/shared-ini-file-loader": "^2.2.7",
-        "@smithy/types": "^2.7.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/shared-ini-file-loader": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4769,13 +5309,14 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.2.1",
-      "license": "Apache-2.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.15",
-        "@smithy/protocol-http": "^3.0.11",
-        "@smithy/querystring-builder": "^2.0.15",
-        "@smithy/types": "^2.7.0",
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/querystring-builder": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4787,10 +5328,11 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.16",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4802,10 +5344,11 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.11",
-      "license": "Apache-2.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4817,11 +5360,12 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.15",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-uri-escape": "^2.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-uri-escape": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4830,13 +5374,15 @@
     },
     "node_modules/@smithy/querystring-builder/node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.15",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4845,23 +5391,26 @@
     },
     "node_modules/@smithy/querystring-parser/node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.8",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
       "dependencies": {
-        "@smithy/types": "^2.7.0"
+        "@smithy/types": "^2.9.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.7",
-      "license": "Apache-2.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4873,16 +5422,17 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.11",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.11",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.4",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/eventstream-codec": "^2.1.1",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4894,12 +5444,15 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.1.18",
-      "license": "Apache-2.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
       "dependencies": {
-        "@smithy/middleware-stack": "^2.0.9",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-stream": "^2.0.23",
+        "@smithy/middleware-endpoint": "^2.4.1",
+        "@smithy/middleware-stack": "^2.1.1",
+        "@smithy/protocol-http": "^3.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-stream": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4911,8 +5464,9 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/types": {
-      "version": "2.7.0",
-      "license": "Apache-2.0",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -4925,11 +5479,12 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.15",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.15",
-        "@smithy/types": "^2.7.0",
+        "@smithy/querystring-parser": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       }
     },
@@ -4938,10 +5493,11 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-base64": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4953,8 +5509,9 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
       "dependencies": {
         "tslib": "^2.5.0"
       }
@@ -4964,8 +5521,9 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "2.1.0",
-      "license": "Apache-2.0",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -4978,10 +5536,11 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
+        "@smithy/is-array-buffer": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4990,11 +5549,13 @@
     },
     "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "2.0.0",
-      "license": "Apache-2.0",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5007,12 +5568,13 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.22",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/smithy-client": "^2.1.18",
-        "@smithy/types": "^2.7.0",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -5025,15 +5587,16 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.29",
-      "license": "Apache-2.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.0.tgz",
+      "integrity": "sha512-iFJp/N4EtkanFpBUtSrrIbtOIBf69KNuve03ic1afhJ9/korDxdM0c6cCH4Ehj/smI9pDCfVv+bqT3xZjF2WaA==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.21",
-        "@smithy/credential-provider-imds": "^2.1.4",
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/property-provider": "^2.0.16",
-        "@smithy/smithy-client": "^2.1.18",
-        "@smithy/types": "^2.7.0",
+        "@smithy/config-resolver": "^2.1.1",
+        "@smithy/credential-provider-imds": "^2.2.1",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/property-provider": "^2.1.1",
+        "@smithy/smithy-client": "^2.3.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5045,11 +5608,12 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "1.0.7",
-      "license": "Apache-2.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.8",
-        "@smithy/types": "^2.7.0",
+        "@smithy/node-config-provider": "^2.2.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5061,8 +5625,9 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5075,10 +5640,11 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.8",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
       "dependencies": {
-        "@smithy/types": "^2.7.0",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5090,11 +5656,12 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.8",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.8",
-        "@smithy/types": "^2.7.0",
+        "@smithy/service-error-classification": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5106,16 +5673,17 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.23",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.3.1",
-        "@smithy/node-http-handler": "^2.2.1",
-        "@smithy/types": "^2.7.0",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.4.1",
+        "@smithy/node-http-handler": "^2.3.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5127,8 +5695,9 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -5141,10 +5710,11 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "2.0.2",
-      "license": "Apache-2.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
+        "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5156,12 +5726,12 @@
       "license": "0BSD"
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.15.tgz",
-      "integrity": "sha512-9Y+btzzB7MhLADW7xgD6SjvmoYaRkrb/9SCbNGmNdfO47v38rxb90IGXyDtAK0Shl9bMthTmLgjlfYc+vtz2Qw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
+      "integrity": "sha512-kYy6BLJJNif+uqNENtJqWdXcpqo1LS+nj1AfXcDhOpqpSHJSAkVySLyZV9fkmuVO21lzGoxjvd1imGGJHph/IA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.15",
-        "@smithy/types": "^2.7.0",
+        "@smithy/abort-controller": "^2.1.1",
+        "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -6404,6 +6974,7 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7128,6 +7699,7 @@
     },
     "node_modules/ignore": {
       "version": "5.2.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -9228,6 +9800,7 @@
       "version": "0.0.1",
       "license": "GPL-3.0-only",
       "dependencies": {
+        "@aws-sdk/client-cloudfront": "^3.515.0",
         "@aws-sdk/client-sns": "^3.465.0",
         "aws-cdk-lib": "2.113.0",
         "constructs": "^10.3.0",

--- a/packages/graphql-mesh-server/assets/handlers/invalidate-cloudfront-cache.ts
+++ b/packages/graphql-mesh-server/assets/handlers/invalidate-cloudfront-cache.ts
@@ -1,0 +1,29 @@
+import {
+  CloudFrontClient,
+  CreateInvalidationCommand,
+  CreateInvalidationCommandInput,
+  CreateInvalidationCommandOutput,
+} from "@aws-sdk/client-cloudfront";
+
+const cfClient = new CloudFrontClient();
+
+const PATHS = process.env.PATHS as string;
+const DISTRIBUTION_ID = process.env.DISTRIBUTION_ID as string;
+
+export const handler = async (): Promise<CreateInvalidationCommandOutput> => {
+  const paths = PATHS.split(",");
+
+  const invalidationInput: CreateInvalidationCommandInput = {
+    DistributionId: DISTRIBUTION_ID,
+    InvalidationBatch: {
+      Paths: {
+        Quantity: paths.length,
+        Items: paths,
+      },
+      CallerReference: "lambda",
+    },
+  };
+
+  const command = new CreateInvalidationCommand(invalidationInput);
+  return await cfClient.send(command);
+};

--- a/packages/graphql-mesh-server/assets/handlers/invalidate-cloudfront-cache.ts
+++ b/packages/graphql-mesh-server/assets/handlers/invalidate-cloudfront-cache.ts
@@ -25,5 +25,5 @@ export const handler = async (): Promise<CreateInvalidationCommandOutput> => {
   };
 
   const command = new CreateInvalidationCommand(invalidationInput);
-  return await cfClient.send(command);
+  return cfClient.send(command);
 };

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -148,6 +148,11 @@ export type MeshHostingProps = {
    * Any additional custom alarms
    */
   additionalAlarms?: Alarm[];
+
+  /**
+   * CloudFront distribution ID to clear cache on after a Mesh deploy.
+   */
+  cloudFrontDistributionId?: string;
 };
 
 export class MeshHosting extends Construct {
@@ -200,6 +205,7 @@ export class MeshHosting extends Construct {
       service: this.service,
       notificationArn: props.notificationArn,
       notificationRegion: props.notificationRegion,
+      cloudFrontDistributionId: props.cloudFrontDistributionId,
     });
 
     new PerformanceMetrics(this, "cloudwatch", {

--- a/packages/graphql-mesh-server/lib/pipeline.ts
+++ b/packages/graphql-mesh-server/lib/pipeline.ts
@@ -139,7 +139,9 @@ export class CodePipelineService extends Construct {
         new PolicyStatement({
           actions: ["cloudfront:CreateInvalidation"],
           resources: [
-            `arn:aws:cloudfront::${Stack.of(this).account}:distribution/${props.cloudFrontDistributionId}`,
+            `arn:aws:cloudfront::${Stack.of(this).account}:distribution/${
+              props.cloudFrontDistributionId
+            }`,
           ],
           effect: Effect.ALLOW,
         })

--- a/packages/graphql-mesh-server/lib/pipeline.ts
+++ b/packages/graphql-mesh-server/lib/pipeline.ts
@@ -9,7 +9,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as YAML from "yaml";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
-import { Runtime, IFunction, Function } from "aws-cdk-lib/aws-lambda";
+import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { LambdaSubscription } from "aws-cdk-lib/aws-sns-subscriptions";

--- a/packages/graphql-mesh-server/lib/pipeline.ts
+++ b/packages/graphql-mesh-server/lib/pipeline.ts
@@ -130,7 +130,7 @@ export class CodePipelineService extends Construct {
           timeout: Duration.seconds(5),
           environment: {
             PATHS: "/graphql",
-            DISTRIBUTION_ID: props.cloudFrontDistributionId || "",
+            DISTRIBUTION_ID: props.cloudFrontDistributionId,
           },
         }
       );

--- a/packages/graphql-mesh-server/package.json
+++ b/packages/graphql-mesh-server/package.json
@@ -16,10 +16,10 @@
   },
   "homepage": "https://github.com/aligent/cdk-constructs#readme",
   "devDependencies": {
-    "@types/yaml": "^1.9.7",
+    "@types/aws-lambda": "^8.10.122",
     "@types/jest": "^29.5.10",
     "@types/node": "20.6.3",
-    "@types/aws-lambda": "^8.10.122",
+    "@types/yaml": "^1.9.7",
     "aws-cdk": "2.113.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
@@ -27,10 +27,11 @@
     "typescript": "~5.3.2"
   },
   "dependencies": {
-    "yaml": "^2.3.1",
+    "@aws-sdk/client-cloudfront": "^3.515.0",
+    "@aws-sdk/client-sns": "^3.465.0",
     "aws-cdk-lib": "2.113.0",
     "constructs": "^10.3.0",
     "source-map-support": "^0.5.21",
-    "@aws-sdk/client-sns": "^3.465.0"
+    "yaml": "^2.3.1"
   }
 }


### PR DESCRIPTION
**Description of the proposed changes**  

* Adds an optional lambda function that invalidates the `/graphql` endpoint on a successful mesh deployment 

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback