### PR TITLE
Provide enough time to handle ten URLs in a chunk

### DIFF
--- a/packages/prerender-fargate/lib/recaching/prerender-recache-api-construct.ts
+++ b/packages/prerender-fargate/lib/recaching/prerender-recache-api-construct.ts
@@ -83,7 +83,7 @@ export class PrerenderRecacheApi extends Construct {
         timeout: Duration.seconds(120),
       }),
       deployDeadLetterQueue: false,
-      queueProps: { visibilityTimeout: Duration.minutes(60) },
+      queueProps: { visibilityTimeout: Duration.minutes(120) },
     });
   }
 }

--- a/packages/prerender-fargate/lib/recaching/prerender-recache-api-construct.ts
+++ b/packages/prerender-fargate/lib/recaching/prerender-recache-api-construct.ts
@@ -83,7 +83,7 @@ export class PrerenderRecacheApi extends Construct {
         timeout: Duration.seconds(120),
       }),
       deployDeadLetterQueue: false,
-      queueProps: { visibilityTimeout: Duration.minutes(120) },
+      queueProps: { visibilityTimeout: Duration.minutes(60) },
     });
   }
 }

--- a/packages/prerender-fargate/lib/recaching/prerender-recache-api-construct.ts
+++ b/packages/prerender-fargate/lib/recaching/prerender-recache-api-construct.ts
@@ -80,7 +80,7 @@ export class PrerenderRecacheApi extends Construct {
       existingProducerLambdaObj: apiHandler,
       existingConsumerLambdaObj: new NodejsFunction(this, "consumer", {
         reservedConcurrentExecutions: options.maxConcurrentExecutions,
-        timeout: Duration.seconds(60),
+        timeout: Duration.seconds(120),
       }),
       deployDeadLetterQueue: false,
       queueProps: { visibilityTimeout: Duration.minutes(60) },


### PR DESCRIPTION

**Description of the proposed changes**  

* Recaching one URL usually takes ~ 10 seconds. The maximum number of URLs in one recaching request chunk is 10, so 60 seconds was not enough to finish them up before the timeout. This change provides ample time for the lambda to finish the recaching.  

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback