### PR TITLE
Hotfix: Update node version

### DIFF
--- a/packages/static-hosting/lib/arbitrary-path-remap.ts
+++ b/packages/static-hosting/lib/arbitrary-path-remap.ts
@@ -20,7 +20,7 @@ export class ArbitraryPathRemapFunction extends Construct {
       {
         code: Bundling.bundle({
           entry: `${__dirname}/handlers/remap.ts`,
-          runtime: Runtime.NODEJS_14_X,
+          runtime: Runtime.NODEJS_18_X,
           sourceMap: true,
           projectRoot: `${__dirname}/handlers/`,
           depsLockFilePath: `${__dirname}/handlers/package-lock.json`,

--- a/packages/static-hosting/lib/arbitrary-path-remap.ts
+++ b/packages/static-hosting/lib/arbitrary-path-remap.ts
@@ -20,7 +20,7 @@ export class ArbitraryPathRemapFunction extends Construct {
       {
         code: Bundling.bundle({
           entry: `${__dirname}/handlers/remap.ts`,
-          runtime: Runtime.NODEJS_18_X,
+          runtime: Runtime.NODEJS_16_X,
           sourceMap: true,
           projectRoot: `${__dirname}/handlers/`,
           depsLockFilePath: `${__dirname}/handlers/package-lock.json`,


### PR DESCRIPTION

**Description of the proposed changes**  
Update to use Node 16 for the path remap so older stacks can still be deployed.

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  
This will be an issue again on Jul 15, 2024 as node 16 functions will be blocked from being created then. But any updates to higher node versions would require an update to CDK V2

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback