### PR TITLE
DO-1394: return cached object when found, without proceeding to fetch origin

### DIFF
--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -88,7 +88,7 @@ if (process.env.ENABLE_REDIRECT_CACHE.toLowerCase() === 'true'){
                             res.setHeader('Location', result.Metadata.location);
                         }
                         // default 200 for legacy objects that do not have Metadata.httpreturncode defined
-                        req.prerender.statusCode = result.Metadata.httpreturncode || 200
+                        return res.send(result.Metadata.httpreturncode || 200, result.Body);
                     } else {
                         console.error(`Fetching cached object from S3 bucket failed with error: ${err.code}`);
                     }

--- a/packages/prerender-fargate/package.json
+++ b/packages/prerender-fargate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-prerender-fargate",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A construct to host Prerender in Fargate",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Description of the proposed changes**  

* Rolling back the change made in [7f8175a](https://github.com/aligent/cdk-constructs/pull/1273/commits/7f8175a89c9b0bec27da6dd8c05484f0f0e63b44) to stop the app from fetching origin after checking the cached object. This caused unnecessarily high response time.

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback