### PR TITLE
DO-1557: disable checking CORS

### DIFF
--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -16,7 +16,7 @@ const crypto = require('crypto');
 const s3Cache = require('prerender-aws-s3-cache');
 
 const server = prerender({
-    chromeFlags: ['--no-sandbox', '--headless', '--disable-gpu', '--remote-debugging-port=9222', '--hide-scrollbars', '--disable-dev-shm-usage'],
+    chromeFlags: ['--no-sandbox', '--headless', '--disable-gpu', '--disable-web-security', '--remote-debugging-port=9222', '--hide-scrollbars', '--disable-dev-shm-usage'],
     forwardHeaders: true,
     chromeLocation: '/usr/bin/chromium-browser'
 });

--- a/packages/prerender-fargate/package.json
+++ b/packages/prerender-fargate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-prerender-fargate",
-  "version": "2.3.1",
+  "version": "2.3.3",
   "description": "A construct to host Prerender in Fargate",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
… to allow the custom x-prerender req header to go through


**Description of the proposed changes**  

* the custom _x-prerender_ req header was causing "timed out" error as it is not in the Access-Control-Allow-Headers response header.
* suppressing this security check on headless chrome to ignore the CORS header.
* release 2.3.3

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback