### PR TITLE
DO-1394: v2.3.4: bump up default service task container size to avoid…

### DIFF
--- a/packages/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate.ts
@@ -152,8 +152,8 @@ export class PrerenderFargate extends Construct {
           cluster,
           serviceName: `${prerenderName}-service`,
           desiredCount: desiredInstanceCount || 1,
-          cpu: instanceCPU || 512, // 0.5 vCPU default
-          memoryLimitMiB: instanceMemory || 1024, // 1 GB default to give Chrome enough memory
+          cpu: instanceCPU || 2048, // 2 vCPU default
+          memoryLimitMiB: instanceMemory || 4096, // 4 GB default to give Chrome enough memory
           taskImageOptions: {
             containerName: `${prerenderName}-container`,
             image: ecs.ContainerImage.fromDockerImageAsset(asset),

--- a/packages/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate.ts
@@ -203,7 +203,7 @@ export class PrerenderFargate extends Construct {
 
     // Setup AutoScaling policy
     const scaling = fargateService.service.autoScaleTaskCount({
-      maxCapacity: maxInstanceCount || 2,
+      maxCapacity: maxInstanceCount || 4,
       minCapacity: minInstanceCount || 1,
     });
     scaling.scaleOnCpuUtilization(`${prerenderName}-scaling`, {

--- a/packages/prerender-fargate/package.json
+++ b/packages/prerender-fargate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-prerender-fargate",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "A construct to host Prerender in Fargate",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
… resources from being bottlenecked


**Description of the proposed changes**  

* 0.5vCPU/1GB --> 2vCPU/4GB for better performance by default
* Default mininum/maximum unchanged as 1 and 2, respectively.

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback