### PR TITLE
feat: support custom waf name for mesh

### DIFF
--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -62,6 +62,11 @@ export interface MeshServiceProps {
    */
   secrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
   /**
+   * Name of the WAF
+   * Defaults to 'graphql-mesh-web-acl'
+   */
+  wafName?: string;
+  /**
    * List of IPv4 addresses to block
    */
   blockedIps?: string[];
@@ -457,6 +462,7 @@ export class MeshService extends Construct {
     }
 
     this.firewall = new WebApplicationFirewall(this, "waf", {
+      name: props.wafName,
       scope: Scope.REGIONAL,
       visibilityConfig: {
         cloudWatchMetricsEnabled: true,

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -87,6 +87,11 @@ export type MeshHostingProps = {
    */
   notificationRegion?: string;
   /**
+   * Name of the WAF
+   * Defaults to 'graphql-mesh-web-acl'
+   */
+  wafName?: string;
+  /**
    * List of IPv4 addresses to block
    */
   blockedIps?: string[];


### PR DESCRIPTION
**Description of the proposed changes**  

* Adds support for a custom WAF name. This was already supported from the WAF construct but we weren't passing a prop all the way down. 

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback