### PR TITLE
Add optional props for construct name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9833,7 +9833,7 @@
     },
     "packages/prerender-fargate": {
       "name": "@aligent/cdk-prerender-fargate",
-      "version": "2.3.0",
+      "version": "2.3.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.30.0-alpha.0",

--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -141,6 +141,27 @@ export interface MeshServiceProps {
    * @default authentication-table
    */
   authenticationTable?: string;
+
+  /**
+   * Specify a name for the ECS cluster
+   * 
+   * @default - AWS generated cluster name
+   */
+  clusterName?: string
+
+  /**
+   * Specify a name for the GraphQL service
+   * 
+   * @default - AWS generated service name
+   */
+  serviceName?: string
+
+  /**
+   * Specify a name for the ECR repository
+   * 
+   * @default - AWS generated repository name
+   */
+  repositoryName?: string
 }
 
 export class MeshService extends Construct {
@@ -171,6 +192,7 @@ export class MeshService extends Construct {
     this.repository =
       props.repository ||
       new ecr.Repository(this, "repo", {
+        repositoryName: props.repositoryName !== undefined ? props.repositoryName : undefined,
         removalPolicy: RemovalPolicy.DESTROY,
         autoDeleteImages: true,
       });
@@ -219,6 +241,8 @@ export class MeshService extends Construct {
       vpc: this.vpc,
       containerInsights:
         props.containerInsights !== undefined ? props.containerInsights : true,
+      clusterName:
+        props.clusterName !== undefined ? props.clusterName : undefined,
     });
 
     const environment: { [key: string]: string } = {};

--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -144,24 +144,31 @@ export interface MeshServiceProps {
 
   /**
    * Specify a name for the ECS cluster
-   * 
+   *
    * @default - AWS generated cluster name
    */
-  clusterName?: string
+  clusterName?: string;
 
   /**
    * Specify a name for the GraphQL service
-   * 
+   *
    * @default - AWS generated service name
    */
-  serviceName?: string
+  serviceName?: string;
 
   /**
    * Specify a name for the ECR repository
-   * 
+   *
    * @default - AWS generated repository name
    */
-  repositoryName?: string
+  repositoryName?: string;
+
+  /**
+   * Specify a name for the task definition family
+   *
+   * @default - AWS generated task definition family name
+   */
+  taskDefinitionFamilyName?: string;
 }
 
 export class MeshService extends Construct {
@@ -192,7 +199,8 @@ export class MeshService extends Construct {
     this.repository =
       props.repository ||
       new ecr.Repository(this, "repo", {
-        repositoryName: props.repositoryName !== undefined ? props.repositoryName : undefined,
+        repositoryName:
+          props.repositoryName !== undefined ? props.repositoryName : undefined,
         removalPolicy: RemovalPolicy.DESTROY,
         autoDeleteImages: true,
       });
@@ -291,6 +299,10 @@ export class MeshService extends Construct {
           taskRole: new iam.Role(this, "MeshTaskRole", {
             assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
           }),
+          family:
+            props.taskDefinitionFamilyName !== undefined
+              ? props.taskDefinitionFamilyName
+              : undefined,
         },
         publicLoadBalancer: true, // default,
         taskSubnets: {

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -171,6 +171,13 @@ export type MeshHostingProps = {
    * @default true
    */
   maintenanceAuthKey?: string;
+
+  /**
+   * Whether a DynamoDB table should be created to store session data
+   *
+   * @default authentication-table
+   */
+  authenticationTable?: string;
 };
 
 export class MeshHosting extends Construct {

--- a/packages/graphql-mesh-server/lib/maintenance.ts
+++ b/packages/graphql-mesh-server/lib/maintenance.ts
@@ -1,6 +1,6 @@
 import { Duration, RemovalPolicy } from "aws-cdk-lib";
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
-import { IVpc, Peer, Port, SecurityGroup } from "aws-cdk-lib/aws-ec2";
+import { IVpc, SecurityGroup } from "aws-cdk-lib/aws-ec2";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
@@ -72,7 +72,9 @@ export class Maintenance extends Construct {
       resources: [efsVolume.fileSystemArn, accessPoint.accessPointArn],
     });
 
-    efsVolume.connections.allowDefaultPortFrom(props.fargateService.connections);
+    efsVolume.connections.allowDefaultPortFrom(
+      props.fargateService.connections
+    );
 
     efsVolume.grantReadWrite(props.fargateService.taskDefinition.taskRole);
     props.fargateService.taskDefinition.addToTaskRolePolicy(accessPolicy);

--- a/packages/graphql-mesh-server/lib/maintenance.ts
+++ b/packages/graphql-mesh-server/lib/maintenance.ts
@@ -72,11 +72,7 @@ export class Maintenance extends Construct {
       resources: [efsVolume.fileSystemArn, accessPoint.accessPointArn],
     });
 
-    efsVolumeSecGroup.addIngressRule(
-      Peer.anyIpv4(), // Can't get the IP address of each container as we don't know them at deploy time!
-      Port.tcp(2049),
-      "File access"
-    );
+    efsVolume.connections.allowDefaultPortFrom(props.fargateService.connections);
 
     efsVolume.grantReadWrite(props.fargateService.taskDefinition.taskRole);
     props.fargateService.taskDefinition.addToTaskRolePolicy(accessPolicy);

--- a/packages/graphql-mesh-server/lib/maintenance.ts
+++ b/packages/graphql-mesh-server/lib/maintenance.ts
@@ -1,6 +1,6 @@
 import { Duration, RemovalPolicy } from "aws-cdk-lib";
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
-import { IVpc, SecurityGroup } from "aws-cdk-lib/aws-ec2";
+import { IVpc, Peer, Port, SecurityGroup } from "aws-cdk-lib/aws-ec2";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
@@ -72,8 +72,10 @@ export class Maintenance extends Construct {
       resources: [efsVolume.fileSystemArn, accessPoint.accessPointArn],
     });
 
-    efsVolume.connections.allowDefaultPortFrom(
-      props.fargateService.connections
+    efsVolumeSecGroup.addIngressRule(
+      Peer.ipv4(props.vpc.vpcCidrBlock),
+      Port.tcp(2049),
+      "File access"
     );
 
     efsVolume.grantReadWrite(props.fargateService.taskDefinition.taskRole);

--- a/packages/graphql-mesh-server/lib/pipeline.ts
+++ b/packages/graphql-mesh-server/lib/pipeline.ts
@@ -48,6 +48,13 @@ export interface CodePipelineServiceProps {
    * CloudFront distribution ID to clear cache on.
    */
   cloudFrontDistributionId?: string;
+
+  /**
+   * Deployment pipeline name
+   *
+   * @default AWS CloudFormation generates an ID and uses that for the pipeline name
+   */
+  pipelineName?: string;
 }
 
 export class CodePipelineService extends Construct {
@@ -56,7 +63,10 @@ export class CodePipelineService extends Construct {
   constructor(scope: Construct, id: string, props: CodePipelineServiceProps) {
     super(scope, id);
 
-    this.pipeline = new Pipeline(this, "deploy-pipeline");
+    this.pipeline = new Pipeline(this, "deploy-pipeline", {
+      pipelineName:
+        props.pipelineName !== undefined ? props.pipelineName : undefined,
+    });
 
     const sourceOutput = new Artifact();
     const sourceAction = new pipe_actions.EcrSourceAction({


### PR DESCRIPTION
**Description of the proposed changes**  

* Adds optional names to ECS cluster, service and repository, looks more readable in the AWS console
* Removes the any IP4v security group rule in favour for service's security group (the other option is to allow VPC CIDR block if other things in the VPC needs access)
