### PR TITLE
feat: add ecs tag permission to pipe

### DIFF
--- a/packages/graphql-mesh-server/lib/pipeline.ts
+++ b/packages/graphql-mesh-server/lib/pipeline.ts
@@ -113,7 +113,7 @@ export class CodePipelineService extends Construct {
       sid: "AllowTaggingEcsResource",
       actions: ["ecs:TagResource"],
       resources: [
-        `arn:aws:ecs:${/* TODO: region */ ""}:*:task/${
+        `arn:aws:ecs:${Stack.of(this).region}:*:task/${
           props.service.cluster.clusterName
         }/*`,
       ],

--- a/packages/graphql-mesh-server/lib/pipeline.ts
+++ b/packages/graphql-mesh-server/lib/pipeline.ts
@@ -10,7 +10,12 @@ import * as path from "path";
 import * as YAML from "yaml";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
-import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import {
+  Effect,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { LambdaSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
 import {
@@ -103,6 +108,22 @@ export class CodePipelineService extends Construct {
         }),
       ],
     });
+
+    const tagECSPermission = new PolicyStatement({
+      sid: "AllowTaggingEcsResource",
+      actions: ["ecs:TagResource"],
+      resources: [
+        `arn:aws:ecs:${/* TODO: region */ ""}:*:task/${
+          props.service.cluster.clusterName
+        }/*`,
+      ],
+    });
+
+    const tagECSRole = new Role(this, "tagEcsRole", {
+      assumedBy: new ServicePrincipal("ecs-tasks.amazonaws.com"),
+    });
+    tagECSRole.addToPolicy(tagECSPermission);
+
     this.pipeline.addStage({
       stageName: "Deploy",
       actions: [
@@ -111,6 +132,7 @@ export class CodePipelineService extends Construct {
           service: props.service,
           input: buildOutput,
           deploymentTimeout: Duration.minutes(10),
+          role: tagECSRole,
         }),
       ],
     });


### PR DESCRIPTION
**Description of the proposed changes**  

* Adds tag permissions to ECS deployment pipeline. This way when the pipe triggers a deployment to ECS, if the task requires a tag it has permission to add it.

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback