### PR TITLE
chore: Add props to top level construct

### DIFF
--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -285,7 +285,8 @@ export class MeshService extends Construct {
     const fargateService =
       new ecsPatterns.ApplicationLoadBalancedFargateService(this, `fargate`, {
         cluster,
-        serviceName: props.serviceName !== undefined ? props.serviceName : undefined,
+        serviceName:
+          props.serviceName !== undefined ? props.serviceName : undefined,
         certificate,
         enableExecuteCommand: true,
         cpu: props.cpu || 512, // 0.5 vCPU

--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -285,6 +285,7 @@ export class MeshService extends Construct {
     const fargateService =
       new ecsPatterns.ApplicationLoadBalancedFargateService(this, `fargate`, {
         cluster,
+        serviceName: props.serviceName !== undefined ? props.serviceName : undefined,
         certificate,
         enableExecuteCommand: true,
         cpu: props.cpu || 512, // 0.5 vCPU

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -178,6 +178,34 @@ export type MeshHostingProps = {
    * @default authentication-table
    */
   authenticationTable?: string;
+
+  /**
+   * Specify a name for the ECS cluster
+   *
+   * @default - AWS generated cluster name
+   */
+  clusterName?: string;
+
+  /**
+   * Specify a name for the GraphQL service
+   *
+   * @default - AWS generated service name
+   */
+  serviceName?: string;
+
+  /**
+   * Specify a name for the ECR repository
+   *
+   * @default - AWS generated repository name
+   */
+  repositoryName?: string;
+
+  /**
+   * Specify a name for the task definition family
+   *
+   * @default - AWS generated task definition family name
+   */
+  taskDefinitionFamilyName?: string;
 };
 
 export class MeshHosting extends Construct {


### PR DESCRIPTION
**Description of the proposed changes**  

* :facepalm: I forgot to use `serviceName` prop in the actual construct
* All the props added needed to be actually available at the top level construct so they can be passed down #1353 
