### PR TITLE
reorder custom behaviors to be evaluated before other static mappings

### DIFF
--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -478,6 +478,11 @@ export class StaticHosting extends Construct {
 
     const additionalBehaviors: Record<string, Writeable<BehaviorOptions>> = {};
 
+    // If additional behaviours are provided via props, then merge, overriding generated behaviours if required.
+    if (props.additionalBehaviors) {
+      Object.assign(additionalBehaviors, props.additionalBehaviors);
+    }
+
     if (props.backendHost) {
       backendOrigin = new HttpOrigin(props.backendHost);
 
@@ -523,11 +528,6 @@ export class StaticHosting extends Construct {
         additionalBehaviors[path].responseHeadersPolicy =
           props.responseHeadersPolicies.additionalBehaviorResponsePolicy[path];
       }
-    }
-
-    // If additional behaviours are provided via props, then merge, overriding generated behaviours if required.
-    if (props.additionalBehaviors) {
-      Object.assign(additionalBehaviors, props.additionalBehaviors);
     }
 
     const distributionProps: DistributionProps = {

--- a/packages/static-hosting/package.json
+++ b/packages/static-hosting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-static-hosting",
-  "version": "2.0.0",
+  "version": "2.3.1",
   "main": "index.js",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/aligent/aws-cdk-static-hosting-stack#readme",


### PR DESCRIPTION

**Description of the proposed changes**  

* Let custom behaviors listed first before static file extension mapping to avoid any file requests in the custom behavior from getting caught by the preceeding static mappings

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback