### PR TITLE
Fix/prerender behaviour

### DIFF
--- a/packages/prerender-proxy/lib/handlers/cache-control.ts
+++ b/packages/prerender-proxy/lib/handlers/cache-control.ts
@@ -7,9 +7,8 @@ export const handler = async (
   const cacheKey = process.env.PRERENDER_CACHE_KEY || "x-prerender-requestid";
   const cacheMaxAge = process.env.PRERENDER_CACHE_MAX_AGE || "0";
   const response = event.Records[0].cf.response;
-
   if (response.headers[`${cacheKey}`]) {
-    response.headers["Cache-Control"] = [
+    response.headers["cache-control"] = [
       {
         key: "Cache-Control",
         value: `max-age=${cacheMaxAge}`,

--- a/packages/prerender-proxy/package.json
+++ b/packages/prerender-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-prerender-proxy",
-  "version": "2.0.0",
+  "version": "2.1.4",
   "description": "Cloudfront Lambda@Edge constructs for integrating with prerender.io",
   "main": "index.js",
   "scripts": {

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -427,14 +427,21 @@ export class StaticHosting extends Construct {
     const originRequestPolicy =
       props.defaultBehaviorRequestPolicy ||
       new OriginRequestPolicy(this, "S3OriginRequestPolicy", {
-        headerBehavior:
-          OriginRequestHeaderBehavior.allowList("x-forwarded-host"),
+        headerBehavior: OriginRequestHeaderBehavior.allowList(
+          "x-forwarded-host",
+          "x-request-prerender",
+          "x-prerender"
+        ),
       });
 
     const originCachePolicy =
       props.defaultBehaviorCachePolicy ||
       new CachePolicy(this, "S3OriginCachePolicy", {
-        headerBehavior: CacheHeaderBehavior.allowList("x-forwarded-host"),
+        headerBehavior: CacheHeaderBehavior.allowList(
+          "x-forwarded-host",
+          "x-request-prerender",
+          "x-prerender"
+        ),
         enableAcceptEncodingBrotli: true,
         enableAcceptEncodingGzip: true,
       });

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -317,8 +317,8 @@ export class StaticHosting extends Construct {
     const siteNameArray: Array<string> = [siteName];
     const enforceSSL = props.enforceSSL !== false;
     const enableStaticFileRemap = props.enableStaticFileRemap !== false;
-    const defaultRootObject = props.defaultRootObject ?? "/index.html";
-    const errorResponsePagePath = props.errorResponsePagePath ?? "/index.html";
+    const defaultRootObject = props.defaultRootObject ?? "index.html";
+    const errorResponsePagePath = props.errorResponsePagePath ?? "index.html";
     const defaultBehaviorEdgeLambdas = props.defaultBehaviorEdgeLambdas ?? [];
     const disableCSP = props.disableCSP === true;
 


### PR DESCRIPTION
**Description of the proposed changes**  

* Overwrite cache-control header set by the Origin, by updating the case to match the original one
* Remove excessive slash that could cause malfuncioning when {{URL}}//index.html is called
* Add prerender headers to the cache key list


**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback