### PR TITLE
[Legacy] let prerender response override cache-control header set, by matching the case

### DIFF
--- a/packages/prerender-proxy/lib/handlers/cache-control.ts
+++ b/packages/prerender-proxy/lib/handlers/cache-control.ts
@@ -12,7 +12,7 @@ export const handler = async (
   const response = event.Records[0].cf.response;
 
   if (response.headers[`${cacheKey}`]) {
-    response.headers["Cache-Control"] = [
+    response.headers["cache-control"] = [
       {
         key: "Cache-Control",
         value: `max-age=${cacheMaxAge}`,

--- a/packages/prerender-proxy/package.json
+++ b/packages/prerender-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-prerender-proxy",
-  "version": "0.1.7",
+  "version": "1.0.2",
   "description": "A Cloudfront Lambda@Edge stack for integrating with prerender.io",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Description of the proposed changes**  

* Overwrite cache-control header set by the Origin, by updating the case to match the original one


**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback