### PR TITLE
fix: ignore wildcards at end of path

### DIFF
--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -503,7 +503,8 @@ export class StaticHosting extends Construct {
     } as Behavior;
 
     // If the remap is to a different path, create a Lambda@Edge function to handle this
-    if (from !== to) {
+    // Ignore wildcards at the end of a path
+    if (from.replace(/\*$/, "") !== to) {
       // Remove special characters from path
       const id = from.replace(/[&/\\#,+()$~%'":*?<>{}]/g, "-");
 


### PR DESCRIPTION
**Description of the proposed changes**  

* Ignore wildcards at the end of from when routing from CDN to the BE. (Required for legacy project but have included here for CDK 2: https://github.com/aligent/cdk-constructs/pull/1371)

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback