### PR TITLE
fix: ignore ending wildcards

### DIFF
--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -614,8 +614,8 @@ export class StaticHosting extends Construct {
     const lambdas: EdgeLambda[] = [];
 
     // If the remap is to a different path, create a Lambda@Edge function to handle this
-    if (from !== to) {
-      // Remove special characters from path
+    // Remove special characters from path
+    if (from.replace(/\*$/, "") !== to) {
       const id = from.replace(/[&/\\#,+()$~%'":*?<>{}]/g, "-");
 
       const remapFunction = new PathRemapFunction(


### PR DESCRIPTION
**Description of the proposed changes**  

* Ignore wildcards at the end of from when routing from CDN to the BE. 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback