### PR TITLE
chore: upgrade legacy lambda to use node 16

### DIFF
--- a/packages/basic-auth/lib/basic-auth-construct.ts
+++ b/packages/basic-auth/lib/basic-auth-construct.ts
@@ -21,7 +21,7 @@ export class BasicAuthFunction extends Construct {
       {
         code: Bundling.bundle({
           entry: `${__dirname}/handlers/basic-auth.ts`,
-          runtime: Runtime.NODEJS_14_X,
+          runtime: Runtime.NODEJS_16_X,
           sourceMap: true,
           projectRoot: `${__dirname}/handlers/`,
           depsLockFilePath: `${__dirname}/handlers/package-lock.json`,
@@ -33,7 +33,7 @@ export class BasicAuthFunction extends Construct {
             "process.env.AUTH_PASSWORD": JSON.stringify(options.password),
           },
         } as any),
-        runtime: Runtime.NODEJS_14_X,
+        runtime: Runtime.NODEJS_16_X,
         handler: "index.handler",
       }
     );

--- a/packages/cloudfront-security-headers/lib/index.ts
+++ b/packages/cloudfront-security-headers/lib/index.ts
@@ -32,13 +32,13 @@ export class SecurityHeaderFunction extends cdk.Construct {
       {
         code: Bundling.bundle({
           entry: `${__dirname}/handlers/security-header.ts`,
-          runtime: Runtime.NODEJS_14_X,
+          runtime: Runtime.NODEJS_16_X,
           sourceMap: true,
           projectRoot: `${__dirname}/handlers/`,
           depsLockFilePath: `${__dirname}/handlers/package-lock.json`,
           define: defineOptions,
         } as any), // TODO fix typing
-        runtime: Runtime.NODEJS_14_X,
+        runtime: Runtime.NODEJS_16_X,
         handler: "index.handler",
       }
     );

--- a/packages/prerender-proxy/lib/error-response-construct.ts
+++ b/packages/prerender-proxy/lib/error-response-construct.ts
@@ -24,7 +24,7 @@ export class ErrorResponseFunction extends Construct {
       {
         code: Bundling.bundle({
           entry: `${__dirname}/handlers/error-response.ts`,
-          runtime: Runtime.NODEJS_14_X,
+          runtime: Runtime.NODEJS_16_X,
           sourceMap: true,
           projectRoot: `${__dirname}/handlers/`,
           depsLockFilePath: `${__dirname}/handlers/package-lock.json`,
@@ -35,7 +35,7 @@ export class ErrorResponseFunction extends Construct {
             "process.env.PATH_PREFIX": JSON.stringify(options.pathPrefix ?? ""),
           },
         } as any),
-        runtime: Runtime.NODEJS_14_X,
+        runtime: Runtime.NODEJS_16_X,
         handler: "index.handler",
       }
     );

--- a/packages/prerender-proxy/lib/prerender-cf-cache-control-construct.ts
+++ b/packages/prerender-proxy/lib/prerender-cf-cache-control-construct.ts
@@ -25,7 +25,7 @@ export class CloudFrontCacheControl extends Construct {
       {
         code: Bundling.bundle({
           entry: `${__dirname}/handlers/cache-control.ts`,
-          runtime: Runtime.NODEJS_14_X,
+          runtime: Runtime.NODEJS_16_X,
           sourceMap: true,
           projectRoot: `${__dirname}/handlers/`,
           depsLockFilePath: `${__dirname}/handlers/package-lock.json`,
@@ -41,7 +41,7 @@ export class CloudFrontCacheControl extends Construct {
             ),
           },
         } as any),
-        runtime: Runtime.NODEJS_14_X,
+        runtime: Runtime.NODEJS_16_X,
         handler: "index.handler",
       }
     );

--- a/packages/prerender-proxy/lib/prerender-check-construct.ts
+++ b/packages/prerender-proxy/lib/prerender-check-construct.ts
@@ -15,12 +15,12 @@ export class PrerenderCheckFunction extends Construct {
       {
         code: Bundling.bundle({
           entry: `${__dirname}/handlers/prerender-check.ts`,
-          runtime: Runtime.NODEJS_14_X,
+          runtime: Runtime.NODEJS_16_X,
           sourceMap: true,
           projectRoot: `${__dirname}/handlers/`,
           depsLockFilePath: `${__dirname}/handlers/package-lock.json`,
         } as any),
-        runtime: Runtime.NODEJS_14_X,
+        runtime: Runtime.NODEJS_16_X,
         handler: "index.handler",
       }
     );

--- a/packages/prerender-proxy/lib/prerender-construct.ts
+++ b/packages/prerender-proxy/lib/prerender-construct.ts
@@ -22,7 +22,7 @@ export class PrerenderFunction extends Construct {
       {
         code: Bundling.bundle({
           entry: `${__dirname}/handlers/prerender.ts`,
-          runtime: Runtime.NODEJS_14_X,
+          runtime: Runtime.NODEJS_16_X,
           sourceMap: true,
           projectRoot: `${__dirname}/handlers/`,
           depsLockFilePath: `${__dirname}/handlers/package-lock.json`,
@@ -39,7 +39,7 @@ export class PrerenderFunction extends Construct {
             ),
           },
         } as any),
-        runtime: Runtime.NODEJS_14_X,
+        runtime: Runtime.NODEJS_16_X,
         handler: "index.handler",
       }
     );

--- a/packages/static-hosting/lib/arbitrary-path-remap.ts
+++ b/packages/static-hosting/lib/arbitrary-path-remap.ts
@@ -31,7 +31,7 @@ export class ArbitraryPathRemapFunction extends Construct {
             "process.env.REMAP_PATH": JSON.stringify(options.path),
           },
         } as any),
-        runtime: Runtime.NODEJS_14_X,
+        runtime: Runtime.NODEJS_16_X,
         handler: "index.handler",
       }
     );


### PR DESCRIPTION
**Description of the proposed changes**  

* Upgrade all instances of Node 14 to Node 16. The highest version of Node on CDK 1 is Node 16 so we should be upgrading existing infras to use CDK 2 where possible. 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback