### PR TITLE
DO-1631: Use secrets manager for passing secrets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9848,7 +9848,7 @@
     },
     "packages/prerender-fargate": {
       "name": "@aligent/cdk-prerender-fargate",
-      "version": "2.3.5",
+      "version": "2.3.8",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.30.0-alpha.0",
@@ -9864,7 +9864,7 @@
     },
     "packages/prerender-proxy": {
       "name": "@aligent/cdk-prerender-proxy",
-      "version": "2.0.0",
+      "version": "2.1.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@aligent/cdk-esbuild": "^2.0",
@@ -9924,7 +9924,7 @@
     },
     "packages/static-hosting": {
       "name": "@aligent/cdk-static-hosting",
-      "version": "2.3.1",
+      "version": "2.3.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@aligent/cdk-esbuild": "^2.0",

--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -62,7 +62,9 @@ export interface MeshServiceProps {
    *
    * @deprecated - Use secrets instead
    */
-  ssmSecrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
+  ssmSecrets?: {
+    [key: string]: ssm.IStringParameter | ssm.IStringListParameter;
+  };
 
   /**
    * ECS Secrets to pass through to the container as secrets

--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -63,9 +63,11 @@ export interface MeshServiceProps {
   secrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
 
   /**
-   * ECS Secrets
+   * ECS Secrets to pass through to the container as secrets
+   *
+   * The key values can be referenced from either SSM or Secrets manager
    */
-  secretsV2: { [key: string]: ecs.Secret };
+  secretsV2?: { [key: string]: ecs.Secret };
 
   /**
    * Name of the WAF

--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -61,6 +61,12 @@ export interface MeshServiceProps {
    * SSM values to pass through to the container as secrets
    */
   secrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
+
+  /**
+   * ECS Secrets
+   */
+  secretsV2: { [key: string]: ecs.Secret };
+
   /**
    * Name of the WAF
    * Defaults to 'graphql-mesh-web-acl'
@@ -295,7 +301,7 @@ export class MeshService extends Construct {
           image: ecs.ContainerImage.fromEcrRepository(this.repository),
           enableLogging: true, // default
           containerPort: 4000, // graphql mesh gateway port
-          secrets: secrets,
+          secrets: props.secretsV2 ? props.secretsV2 : secrets, // Prefer v2 secrets using secrets manager
           environment: environment,
           logDriver: logDriver,
           taskRole: new iam.Role(this, "MeshTaskRole", {

--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -59,15 +59,17 @@ export interface MeshServiceProps {
   };
   /**
    * SSM values to pass through to the container as secrets
+   *
+   * @deprecated - Use secrets instead
    */
-  secrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
+  ssmSecrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
 
   /**
    * ECS Secrets to pass through to the container as secrets
    *
    * The key values can be referenced from either SSM or Secrets manager
    */
-  secretsV2?: { [key: string]: ecs.Secret };
+  secrets?: { [key: string]: ecs.Secret };
 
   /**
    * Name of the WAF
@@ -276,10 +278,10 @@ export class MeshService extends Construct {
     }
 
     // Construct secrets from provided ssm values
-    const secrets: { [key: string]: ecs.Secret } = {};
-    props.secrets = props.secrets || {};
-    for (const [key, ssm] of Object.entries(props.secrets)) {
-      secrets[key] = ecs.Secret.fromSsmParameter(ssm);
+    const ssmSecrets: { [key: string]: ecs.Secret } = {};
+    props.ssmSecrets = props.ssmSecrets || {};
+    for (const [key, ssm] of Object.entries(props.ssmSecrets)) {
+      ssmSecrets[key] = ecs.Secret.fromSsmParameter(ssm);
     }
 
     // Configure a custom log driver and group
@@ -303,7 +305,7 @@ export class MeshService extends Construct {
           image: ecs.ContainerImage.fromEcrRepository(this.repository),
           enableLogging: true, // default
           containerPort: 4000, // graphql mesh gateway port
-          secrets: props.secretsV2 ? props.secretsV2 : secrets, // Prefer v2 secrets using secrets manager
+          secrets: props.secrets ? props.secrets : ssmSecrets, // Prefer v2 secrets using secrets manager
           environment: environment,
           logDriver: logDriver,
           taskRole: new iam.Role(this, "MeshTaskRole", {

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -19,6 +19,7 @@ import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { Maintenance } from "./maintenance";
+import { Secret } from "aws-cdk-lib/aws-ecs";
 
 export type MeshHostingProps = {
   /**
@@ -68,6 +69,9 @@ export type MeshHostingProps = {
    * SSM values to pass through to the container as secrets
    */
   secrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
+
+  secretsV2: { [key: string]: Secret };
+
   /**
    * Pass custom cpu scaling steps
    * Default value:

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -70,7 +70,12 @@ export type MeshHostingProps = {
    */
   secrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
 
-  secretsV2: { [key: string]: Secret };
+  /**
+   * ECS Secrets to pass through to the container as secrets
+   *
+   * The key values can be referenced from either SSM or Secrets manager
+   */
+  secretsV2?: { [key: string]: Secret };
 
   /**
    * Pass custom cpu scaling steps

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -70,7 +70,9 @@ export type MeshHostingProps = {
    *
    * @deprecated - Use secrets instead
    */
-  ssmSecrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
+  ssmSecrets?: {
+    [key: string]: ssm.IStringParameter | ssm.IStringListParameter;
+  };
 
   /**
    * ECS Secrets to pass through to the container as secrets

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -67,15 +67,17 @@ export type MeshHostingProps = {
   };
   /**
    * SSM values to pass through to the container as secrets
+   *
+   * @deprecated - Use secrets instead
    */
-  secrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
+  ssmSecrets?: { [key: string]: ssm.IStringParameter | ssm.IStringListParameter };
 
   /**
    * ECS Secrets to pass through to the container as secrets
    *
    * The key values can be referenced from either SSM or Secrets manager
    */
-  secretsV2?: { [key: string]: Secret };
+  secrets?: { [key: string]: Secret };
 
   /**
    * Pass custom cpu scaling steps


### PR DESCRIPTION
**Description of the proposed changes**  

* Added a new prop for passing secrets via secrets manager. The ECS task execution will pass the secret value as a JSON object when launching the task.

Example:

![image](https://github.com/aligent/cdk-constructs/assets/40108018/86cc84ae-6ded-47cd-b274-d78faa2a02b2)
