### PR TITLE
Feature/prerender redirect response

### DIFF
--- a/packages/prerender-fargate/README.md
+++ b/packages/prerender-fargate/README.md
@@ -146,6 +146,19 @@ export class RagPrerenderStackStack extends Stack {
 }
 ```
 
+# Local Development
+
+Prerender can be run locally with docker:
+
+```bash
+
+docker build lib/prerender --tag prerender:1
+docker run -p 3000:3000 -e TOKEN_SECRET='{"token1": "https://www.emaplesite.com.au"}' -e ENABLE_REDIRECT_CACHE='true' -e ENABLE_PRERENDER_HEADER='true' prerender:1
+
+
+curl http://localhost:3000/https://www.emaplesite.com.au/home -H 'x-prerender-token: token1'
+```
+
 ## Acknowledgements
 
 - [prerender.io](https://prerender.io/) - The Prerender service.

--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -200,6 +200,10 @@ server.use({
                 headerMatch = headerMatchRegex.exec(head)
             }
 
+            if (['301', '302'].includes(req.prerender.statusCode )) {
+                req.prerender.content = `This page has moved, redirecting to ${s3Metadata.location}...`;
+            }
+
             if ( statusCodesToCache.includes(req.prerender.statusCode.toString()) ){
                 s3Metadata.httpreturncode = req.prerender.statusCode.toString()
 

--- a/packages/prerender-fargate/package.json
+++ b/packages/prerender-fargate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-prerender-fargate",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A construct to host Prerender in Fargate",
   "main": "index.js",
   "scripts": {

--- a/packages/prerender-fargate/package.json
+++ b/packages/prerender-fargate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-prerender-fargate",
-  "version": "2.3.8",
+  "version": "2.4.0",
   "description": "A construct to host Prerender in Fargate",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Description of the proposed changes**  

* Don't return (or cache) the actual page when it is a redirect (301/302), instead return text saying the page has moved. This aligns with the "usually" in the spec (https://www.rfc-editor.org/rfc/rfc9110#status.301) and may prevent google search issues. It also reduces the size of cache, especially if there are many redirects.
* Additionally I've added instructions on running the prerender fargate container locally since I had to work that out to test this
* I updated the package version to the _current_ one, not sure if that was correct or not

This has been tested against this page that returns a 301: https://www.discountpartysupplies.com.au/food-decor/baking-and-cake-decorating.html

**Screenshots (if applicable)**  

_N/A_

**Other solutions considered (if any)**  

* None

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback