### PR TITLE
fix: revert error response path

### DIFF
--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -127,7 +127,7 @@ export interface StaticHostingProps {
   /**
    * Custom error response page path
    *
-   * @default index.html
+   * @default /index.html
    */
   errorResponsePagePath?: string;
 
@@ -319,7 +319,7 @@ export class StaticHosting extends Construct {
     const enforceSSL = props.enforceSSL !== false;
     const enableStaticFileRemap = props.enableStaticFileRemap !== false;
     const defaultRootObject = props.defaultRootObject ?? "index.html";
-    const errorResponsePagePath = props.errorResponsePagePath ?? "index.html";
+    const errorResponsePagePath = props.errorResponsePagePath ?? "/index.html";
     const defaultBehaviorEdgeLambdas = props.defaultBehaviorEdgeLambdas ?? [];
     const disableCSP = props.disableCSP === true;
 


### PR DESCRIPTION
**Description of the proposed changes**  

Response page paths must begin with a slash. We changed the default to remove the slash which causes errors on deploy. 

![image](https://github.com/aligent/cdk-constructs/assets/6127662/3c971f95-e87d-4b23-ba11-900e49e658fb)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback