### PR TITLE
Hotfix: Allow multiple stacks

### DIFF
--- a/packages/graphql-mesh-server/lib/fargate.ts
+++ b/packages/graphql-mesh-server/lib/fargate.ts
@@ -149,8 +149,9 @@ export interface MeshServiceProps {
    */
   logStreamPrefix?: string;
   /**
-   * Whether a DynamoDB table should be created to store session data
-   * @default authentication-table
+   * Whether a DynamoDB table should be created to store session data,
+   * if not defined a table will not be created.
+   * @default undefined
    */
   authenticationTable?: string;
 
@@ -348,7 +349,7 @@ export class MeshService extends Construct {
       managedPolicyArn: "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess",
     });
 
-    if (props.authenticationTable || props.authenticationTable === undefined) {
+    if (props.authenticationTable) {
       const authTable = new dynamodb.Table(this, "authenticationTable", {
         tableName: props.authenticationTable || "authentication-table",
         partitionKey: {

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -219,6 +219,13 @@ export type MeshHostingProps = {
    * @default - AWS generated task definition family name
    */
   taskDefinitionFamilyName?: string;
+
+  /**
+   * Specify a name for the dashboard
+   *
+   * @default - {stackName}-Mesh-Dashboard
+   */
+  dashboardName?: string;
 };
 
 export class MeshHosting extends Construct {

--- a/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
+++ b/packages/graphql-mesh-server/lib/graphql-mesh-server.ts
@@ -223,7 +223,7 @@ export type MeshHostingProps = {
   /**
    * Specify a name for the dashboard
    *
-   * @default - {stackName}-Mesh-Dashboard
+   * @default - AWS Generated name
    */
   dashboardName?: string;
 };

--- a/packages/graphql-mesh-server/lib/metrics.ts
+++ b/packages/graphql-mesh-server/lib/metrics.ts
@@ -30,6 +30,7 @@ export interface PerformanceMetricsProps {
   logGroup: LogGroup;
   snsTopic?: Topic;
   additionalAlarms?: Alarm[];
+  dashboardName?: string;
 }
 
 export class PerformanceMetrics extends Construct {
@@ -355,7 +356,7 @@ export class PerformanceMetrics extends Construct {
 
     // Create the dashboard
     new Dashboard(this, "dashboard", {
-      dashboardName: "Mesh-Dashboard",
+      dashboardName: props.dashboardName ?? Stack.of(this).stackName + "-Mesh-Dashboard",
       widgets: [
         [new Column(...loadBalancerWidgets), new Column(...wafWidgets)],
         [meshPerformanceLabel],

--- a/packages/graphql-mesh-server/lib/metrics.ts
+++ b/packages/graphql-mesh-server/lib/metrics.ts
@@ -356,7 +356,8 @@ export class PerformanceMetrics extends Construct {
 
     // Create the dashboard
     new Dashboard(this, "dashboard", {
-      dashboardName: props.dashboardName ?? Stack.of(this).stackName + "-Mesh-Dashboard",
+      dashboardName:
+        props.dashboardName ?? Stack.of(this).stackName + "-Mesh-Dashboard",
       widgets: [
         [new Column(...loadBalancerWidgets), new Column(...wafWidgets)],
         [meshPerformanceLabel],

--- a/packages/graphql-mesh-server/lib/metrics.ts
+++ b/packages/graphql-mesh-server/lib/metrics.ts
@@ -356,8 +356,7 @@ export class PerformanceMetrics extends Construct {
 
     // Create the dashboard
     new Dashboard(this, "dashboard", {
-      dashboardName:
-        props.dashboardName ?? Stack.of(this).stackName + "-Mesh-Dashboard",
+      dashboardName: props.dashboardName,
       widgets: [
         [new Column(...loadBalancerWidgets), new Column(...wafWidgets)],
         [meshPerformanceLabel],


### PR DESCRIPTION

**Description of the proposed changes**  
Update the mesh construct so that it can be deployed multiple times to the same account with the same defaults. Currently if you deploy it more than once it will fail and rollback due to creating a dashboard and dynamo DB table with the same name in both stacks. This PR removes the default dynamo DB table and updates the dashboard to include the stack name so it will not conflict.

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback