### PR TITLE
introduce logging to WAF, bumping up to 2.2.0

### DIFF
--- a/packages/waf/lib/waf.ts
+++ b/packages/waf/lib/waf.ts
@@ -79,7 +79,7 @@ export interface WebApplicationFirewallProps {
   postProcessCustomRules?: aws_wafv2.CfnWebACL.RuleProperty[];
 
   /**
-   * Enable CloudWatch logging. Default: false
+   * Enable CloudWatch logging. Default: true
    */
   enableLogging?: boolean;
 
@@ -408,7 +408,8 @@ export class WebApplicationFirewall extends Construct {
       });
     }
 
-    if (props.enableLogging) {
+    const enableLogging = props.enableLogging ?? true;
+    if (enableLogging) {
       const wafLogGroup = new LogGroup(this, `WAF-Logs-${this.web_acl.name}`, {
         retention: props.logRetentionDays
           ? props.logRetentionDays

--- a/packages/waf/package.json
+++ b/packages/waf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/cdk-waf",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "index.js",
   "license": "GPL-3.0-only",
   "homepage": "https://github.com/aligent/aws-cdk-waf-stack#readme",


### PR DESCRIPTION
**Description of the proposed changes**  

* introduce CloudWatch logging to WAF, keeping default as true. 

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

* log group name needs to be "aws-waf-logs-xxxxx" in order to be associated to a WebACL.

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback