### PR TITLE
fix: specifically target mesh container for deploy

### DIFF
--- a/packages/graphql-mesh-server/lib/pipeline.ts
+++ b/packages/graphql-mesh-server/lib/pipeline.ts
@@ -107,7 +107,8 @@ export class CodePipelineService extends Construct {
             },
             CONTAINER_NAME: {
               value:
-                props.service.taskDefinition.defaultContainer?.containerName,
+                props.service.taskDefinition.findContainer("mesh")
+                  ?.containerName,
             },
           },
         }),


### PR DESCRIPTION
**Description of the proposed changes**  

* When nginx is in use, this becomes the default container. However when the mesh deploys we want to target the mesh container. This removes the assumption that the mesh is the default container and instead searches for it.

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback