### PR TITLE
Static hosting behaviour remap options

### DIFF
--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -140,6 +140,13 @@ export interface StaticHostingProps {
   enableStaticFileRemap?: boolean;
 
   /**
+   * Optional additional properties for static file remap behaviours
+   * 
+   * @default none
+   */
+  staticFileRemapOptions?: BehaviorOptions;
+
+  /**
    * Paths to remap on the default behaviour. For example you might remap deployed_sitemap.xml -> sitemap.xml
    * Created a behaviour in CloudFront to handle the remap. If the paths are different
    * it will also deploy a Lambda@Edge function to perform the required remap.
@@ -533,6 +540,7 @@ export class StaticHosting extends Construct {
         additionalBehaviors[`*.${path}`] = {
           origin: s3Origin,
           viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          ...props.staticFileRemapOptions,
         };
       }
     }

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -141,10 +141,10 @@ export interface StaticHostingProps {
 
   /**
    * Optional additional properties for static file remap behaviours
-   * 
+   *
    * @default none
    */
-  staticFileRemapOptions?: BehaviorOptions;
+  staticFileRemapOptions?: Partial<BehaviorOptions>;
 
   /**
    * Paths to remap on the default behaviour. For example you might remap deployed_sitemap.xml -> sitemap.xml
@@ -295,6 +295,7 @@ export interface StaticHostingProps {
 interface remapPath {
   from: string;
   to?: string;
+  behaviour?: Partial<BehaviorOptions>;
 }
 
 export interface ResponseHeaderMappings {
@@ -530,6 +531,7 @@ export class StaticHosting extends Construct {
             origin: backendOrigin,
             viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             edgeLambdas: this.createRemapBehavior(path.from, path.to),
+            ...path.behaviour,
           };
         }
       }
@@ -553,6 +555,7 @@ export class StaticHosting extends Construct {
           origin: s3Origin,
           viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           edgeLambdas: this.createRemapBehavior(path.from, path.to),
+          ...path.behaviour,
         };
       }
     }


### PR DESCRIPTION
**Description of the proposed changes**  

* Adds the option to pass custom behaviour overrides to remap behaviours. 
* This is useful for many reasons, one of which is when you need to customise the cache policy


**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback