### PR TITLE
Behaviour Prefixes (for CDK v2 upgrade)

### DIFF
--- a/packages/prerender-proxy/lib/prerender-lambda-construct.ts
+++ b/packages/prerender-proxy/lib/prerender-lambda-construct.ts
@@ -34,25 +34,25 @@ export class PrerenderLambda extends Construct {
 
     this.prerenderCheckFunction = new PrerenderCheckFunction(
       this,
-      "PrerenderViewerRequest",
+      `${id}-PrerenderViewerRequest`,
       props.prerenderCheckOptions
     );
 
     this.prerenderFunction = new PrerenderFunction(
       this,
-      "PrerenderOriginRequest",
+      `${id}-PrerenderOriginRequest`,
       props.prerenderProps
     );
 
     this.errorResponseFunction = new ErrorResponseFunction(
       this,
-      "ErrorResponse",
+      `${id}-ErrorResponse`,
       props.errorResponseProps
     );
 
     this.cacheControlFunction = new CloudFrontCacheControl(
       this,
-      "PrerenderCloudFrontCacheControl",
+      `${id}-PrerenderCloudFrontCacheControl`,
       props.cacheControlProps
     );
   }

--- a/packages/static-hosting/index.ts
+++ b/packages/static-hosting/index.ts
@@ -1,4 +1,8 @@
-import { StaticHosting, StaticHostingProps } from "./lib/static-hosting";
+import {
+  StaticHosting,
+  StaticHostingProps,
+  remapPath,
+} from "./lib/static-hosting";
 import { CSP } from "./types/csp";
 
-export { StaticHosting, StaticHostingProps, CSP };
+export { StaticHosting, StaticHostingProps, CSP, remapPath };

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -544,16 +544,6 @@ export class StaticHosting extends Construct {
       }
     }
 
-    if (enableStaticFileRemap) {
-      for (const path of this.staticFiles) {
-        additionalBehaviors[`*.${path}`] = {
-          origin: s3Origin,
-          viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          ...props.staticFileRemapOptions,
-        };
-      }
-    }
-
     // Note: A given path may override if the same path is defined both remapPaths and remapBackendPaths. This is an
     // unlikely scenario but worth noting. e.g. `/robots.txt` should be defined in one of the above but not both.
     if (props.remapPaths) {

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -576,17 +576,15 @@ export class StaticHosting extends Construct {
 
     props.defaultBehaviourPrefixes?.forEach(prefix => {
       additionalBehaviors[`${prefix.prefix}*`] = {
-        origin: prefix.behaviourOverride.origin ?? s3Origin,
+        origin: s3Origin,
         viewerProtocolPolicy:
-          prefix.behaviourOverride.viewerProtocolPolicy ??
           ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         edgeLambdas: prefix.behaviourOverride.edgeLambdas,
-        originRequestPolicy:
-          prefix.behaviourOverride.originRequestPolicy ?? originRequestPolicy,
-        cachePolicy: prefix.behaviourOverride.cachePolicy ?? originCachePolicy,
+        originRequestPolicy: originRequestPolicy,
+        cachePolicy: originCachePolicy,
         responseHeadersPolicy:
-          prefix.behaviourOverride.responseHeadersPolicy ??
           responseHeadersPolicy,
+        ...prefix.behaviourOverride
       };
     });
 

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -577,14 +577,11 @@ export class StaticHosting extends Construct {
     props.defaultBehaviourPrefixes?.forEach(prefix => {
       additionalBehaviors[`${prefix.prefix}*`] = {
         origin: s3Origin,
-        viewerProtocolPolicy:
-          ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        edgeLambdas: prefix.behaviourOverride.edgeLambdas,
+        viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         originRequestPolicy: originRequestPolicy,
         cachePolicy: originCachePolicy,
-        responseHeadersPolicy:
-          responseHeadersPolicy,
-        ...prefix.behaviourOverride
+        responseHeadersPolicy: responseHeadersPolicy,
+        ...prefix.behaviourOverride,
       };
     });
 

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -140,7 +140,7 @@ export interface StaticHostingProps {
   enableStaticFileRemap?: boolean;
 
   /**
-   * Overrides default behaviour paths with a prefix and takes in options to apply to each static file behaviour
+   * Overrides default behaviour paths with a prefix and takes in behviour options to apply on the prefix behaviour
    *
    * @default true
    */
@@ -576,12 +576,17 @@ export class StaticHosting extends Construct {
 
     props.defaultBehaviourPrefixes?.forEach(prefix => {
       additionalBehaviors[`${prefix.prefix}*`] = {
-        origin: s3Origin,
-        viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        origin: prefix.behaviourOverride.origin ?? s3Origin,
+        viewerProtocolPolicy:
+          prefix.behaviourOverride.viewerProtocolPolicy ??
+          ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         edgeLambdas: prefix.behaviourOverride.edgeLambdas,
-        originRequestPolicy: originRequestPolicy,
-        cachePolicy: originCachePolicy,
-        responseHeadersPolicy: responseHeadersPolicy,
+        originRequestPolicy:
+          prefix.behaviourOverride.originRequestPolicy ?? originRequestPolicy,
+        cachePolicy: prefix.behaviourOverride.cachePolicy ?? originCachePolicy,
+        responseHeadersPolicy:
+          prefix.behaviourOverride.responseHeadersPolicy ??
+          responseHeadersPolicy,
       };
     });
 

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -140,11 +140,14 @@ export interface StaticHostingProps {
   enableStaticFileRemap?: boolean;
 
   /**
-   * Any prefixes to remapping that should be included in the path such as au or nz
+   * Overrides default behaviour paths with a prefix and takes in options to apply to each static file behaviour
    *
    * @default true
    */
-  behaviourPrefixes?: { prefix: string; edgeLambdas: EdgeLambda[] }[];
+  defaultBehaviourPrefixes?: {
+    prefix: string;
+    behaviourOverride: Partial<BehaviorOptions>;
+  }[];
 
   /**
    * Optional additional properties for static file remap behaviours
@@ -558,7 +561,7 @@ export class StaticHosting extends Construct {
     }
 
     if (enableStaticFileRemap) {
-      const staticFileRemapPrefixes = props.behaviourPrefixes?.map(
+      const staticFileRemapPrefixes = props.defaultBehaviourPrefixes?.map(
         prefix => `${prefix.prefix}/`
       ) || [""];
       staticFileRemapPrefixes.forEach(prefix => {
@@ -571,11 +574,11 @@ export class StaticHosting extends Construct {
       });
     }
 
-    props.behaviourPrefixes?.forEach(prefix => {
+    props.defaultBehaviourPrefixes?.forEach(prefix => {
       additionalBehaviors[`${prefix.prefix}*`] = {
         origin: s3Origin,
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        edgeLambdas: prefix.edgeLambdas,
+        edgeLambdas: prefix.behaviourOverride.edgeLambdas,
         originRequestPolicy: originRequestPolicy,
         cachePolicy: originCachePolicy,
         responseHeadersPolicy: responseHeadersPolicy,


### PR DESCRIPTION
**Description of the proposed changes**  

- Added an `id` tag to prerender function names to avoid duplicate named function issues
- Export remap path from construct for easier uniformity with types
- `behaviourPrefixes` to allow for behaviours on regional prefixes such as `au/` or `nz/`

**Notes to reviewers**  

- These changes allow for the CDK v2 upgrade to work for multiple brands, impact on other clients untested but it is all conditional so shouldn't affect them

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback