### PR TITLE
Change esbuild logic to allow passing thru of custom configuration

### DIFF
--- a/packages/esbuild/esbuild.ts
+++ b/packages/esbuild/esbuild.ts
@@ -9,16 +9,17 @@ export class Esbuild implements ILocalBundling {
 
     // Override with default options
     Object.assign(this.options, {
-      logLevel: options.logLevel ?? "info",
-      sourcemap: options.sourcemap ?? false,
-      bundle: options.bundle ?? true,
-      minify: options.minify ?? true,
-      platform: options.platform ?? "node",
+      logLevel: "info",
+      sourcemap: false,
+      bundle: true,
+      minify: true,
+      platform: "node",
       // Do not minify identifiers, otherwise the exported `handler` function name gets minified failing to start
       // the lambda
       minifyIdentifiers: false,
-      minifyWhitespace: options.minifyWhitespace ?? true,
-      minifySyntax: options.minifySyntax ?? true,
+      minifyWhitespace: true,
+      minifySyntax: true,
+      ...options,
     });
   }
 

--- a/packages/esbuild/esbuild.ts
+++ b/packages/esbuild/esbuild.ts
@@ -9,16 +9,16 @@ export class Esbuild implements ILocalBundling {
 
     // Override with default options
     Object.assign(this.options, {
-      logLevel: "info",
-      sourcemap: false,
-      bundle: true,
-      minify: true,
-      platform: "node",
+      logLevel: options.logLevel ?? "info",
+      sourcemap: options.sourcemap ?? false,
+      bundle: options.bundle ?? true,
+      minify: options.minify ?? true,
+      platform: options.platform ?? "node",
       // Do not minify identifiers, otherwise the exported `handler` function name gets minified failing to start
       // the lambda
       minifyIdentifiers: false,
-      minifyWhitespace: true,
-      minifySyntax: true,
+      minifyWhitespace: options.minifyWhitespace ?? true,
+      minifySyntax: options.minifySyntax ?? true,
     });
   }
 


### PR DESCRIPTION
**Description of the proposed changes**  

* Adjusted the logic of the esbuild behaviour options so that if more than just `define` and `entryPoints` are declared the other values will be used. (such as `minify`)
* Didn't allow overriding of `minifyIdentifiers` as it causes errors

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback