### PR TITLE
fix: add support for http2

### DIFF
--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -578,7 +578,7 @@ export class StaticHosting extends Construct {
       webAclId: props.webAclArn,
       comment: props.comment,
       defaultRootObject: defaultRootObject,
-      httpVersion: HttpVersion.HTTP3,
+      httpVersion: HttpVersion.HTTP2_AND_3,
       sslSupportMethod: SSLMethod.SNI,
       priceClass: PriceClass.PRICE_CLASS_ALL,
       enableLogging: props.enableCloudFrontAccessLogging,


### PR DESCRIPTION
**Description of the proposed changes**  

Despite the AWS docs saying this value is quote: "Maximum HTTP version to support". This is a lie :-1: 

What it *actually* means is what the HTTP version should be with a fallback to version 1.1. If you want HTTP3 to fallback to HTTP2 you must explicitly define that. 

I can't think of a situation where we'd only want HTTP3 but not HTTP2 so I think this is a reasonable default.

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback