### PR TITLE
chore: upgrade prerender to node 22

### DIFF
--- a/packages/prerender-fargate/lib/prerender/Dockerfile
+++ b/packages/prerender-fargate/lib/prerender/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:22-alpine
 
 ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV CHROME_PATH=/usr/lib/chromium/


### PR DESCRIPTION
**Description of the proposed changes**  

* Upgrades the Prerender node image to node 22
* This in turn also upgrades to version of Chrome from 119 to 131

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback