### PR TITLE
Prerender Fargate Leading Slash Logic

### DIFF
--- a/packages/prerender-fargate/lib/prerender/server.js
+++ b/packages/prerender-fargate/lib/prerender/server.js
@@ -238,11 +238,16 @@ server.use({
       }
 
       let headerMatch = headerMatchRegex.exec(head);
-      while (headerMatch) {
-        s3Metadata.location =
-          headerMatch[1].toLowerCase() == "location"
-            ? he.decode(headerMatch[2] || headerMatch[4])
-            : "";
+        while (headerMatch) {
+            const decoded = he.decode(headerMatch[2] || headerMatch[4])
+            if (headerMatch[1].toLowerCase() == "location") {
+                s3Metadata.location = decoded
+                if (!decoded.startsWith('http') && !decoded.startsWith('/')) {
+                    s3Metadata.location = '/' + s3Metadata.location
+                }
+            } else {
+                s3Metadata.location = ""
+            }
         res.setHeader(headerMatch[1] || headerMatch[3], s3Metadata.location);
         req.prerender.content = req.prerender.content
           .toString()


### PR DESCRIPTION
**Description of the proposed changes**  

* A change to prerender's logic when it comes to adding a correct leading slash onto the location returned in 301 redirect responses. This affected some prerender instances and led to redirected URLs having doubly-appended responses for example: `https://example.com/trains/steam-engines/trains/steam-engines` rather than the correct response  `https://example.com/trains/steam-engines`
* Changed the logic to be a little more clear

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback