### PR TITLE
fix: enable corepack during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           ref: ${{ github.event.release.target_commitish }}
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"


### PR DESCRIPTION
**Description of the proposed changes**  

* Enable corepack in the release pipeline so yarn berry can be installed


**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback