### PR TITLE
GeoIP | Modular Region Domains and Rewrite Paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,3 @@ cdk.out
 
 # Used during the publish stage
 .npmignore
-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ cdk.out
 
 # Used during the publish stage
 .npmignore
+*.tgz

--- a/packages/geoip-redirect/README.md
+++ b/packages/geoip-redirect/README.md
@@ -1,4 +1,53 @@
-# Geo-IP Redirect 
-This library provides a construct which creates a Lambda@Edge functions to perform GeoIP redirects.
+# Geo-IP Redirect
 
-These functions are intended to be added to an existing Cloudfront distribution
+![TypeScript version](https://img.shields.io/github/package-json/dependency-version/aligent/cdk-constructs/dev/typescript?filename=packages/geoip-redirect/package.json&color=red) ![AWS CDK version](https://img.shields.io/github/package-json/dependency-version/aligent/cdk-constructs/dev/aws-cdk?filename=packages/geoip-redirect/package.json) ![NPM version](https://img.shields.io/npm/v/%40aligent%2Fcdk-geoip-redirect?color=green)
+
+## Overview
+
+This library provides a construct which creates a Lambda@Edge which is intended to be attached to the Origin Request in a CloudFront distribution. The construct allows a CloudFront website to perform GeoIP redirects to redirect users to a version of the website related to their location such as `.com` `.com.au` or `.co.nz` etc.
+
+The Lambda@Edge function will check if the viewer's country code matches any supported regions. The user's country code for each request is pulled from the `cloudfront-viewer-country`. The construct will match the code to the record with the corresponding regex lookup.
+
+## Usage and Default Geo-IP Redirect options
+
+### `redirectHost` (string)
+
+```
+interface RedirectFunctionOptions {
+	supportedRegions?:  Record<string, DomainOverwrite>;
+	defaultRegionCode: string;
+	defaultDomain: string;
+}
+```
+
+| Property            | Definition                                                                                                                                                                        |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `supportedRegions`  | A record with domain codes as a key (regex) and a domain to redirect to as a value                                                                                                |
+| `defaultRegionCode` | The default region code(s) as regex. These are the regions supported by `defaultDomain`. When multiple codes are used the default will be the first code the default site eg. `AU | NZ`will treat`AU` as the default |
+| `defaultDomain`     | The website's main domain. This will act as a fallback for any unsupported regions                                                                                                |
+
+### Using this package
+
+The two main ways you can use this package are as follows:
+First off your website has a basic domain let's say `www.iamawesome.com` and you serve all content for all regions of the world here such as `www.iamawesome.com/us` or `www.iamawesome.com/au`. For this approach you should use the below method
+
+```
+redirectBehaviourOptions: {
+	defaultDomain: "www.iamawesome.com",
+	defaultRegionCode: "AU|US",
+}
+```
+
+Any region codes that are regexed to be `XX|YY` (note the pipe `|`) will automatically add the matching region as a path suffix to the url.
+
+However perhaps you also have `www.iamawesome.co.nz`. How to redirect to a website that is different from the base domain? To achieve this, you can "hardcode" a domain for a region to use by using the `supportedRegions` value.
+
+```
+redirectBehaviourOptions: {
+	defaultDomain: "www.example.com",
+	defaultRegionCode: "AU|US",
+	supportedRegions: { "NZ": "www.example.co.nz" }
+}
+```
+
+_this package has not been tested with interplanetary domains_

--- a/packages/geoip-redirect/README.md
+++ b/packages/geoip-redirect/README.md
@@ -20,32 +20,33 @@ interface RedirectFunctionOptions {
 }
 ```
 
-| Property            | Definition                                                                                                                                                                        |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `supportedRegions`  | A record with domain codes as a key (regex) and a domain to redirect to as a value                                                                                                |
-| `defaultRegionCode` | The default region code(s) as regex. These are the regions supported by `defaultDomain`. When multiple codes are used the default will be the first code the default site eg. `AU | NZ`will treat`AU` as the default |
-| `defaultDomain`     | The website's main domain. This will act as a fallback for any unsupported regions                                                                                                |
+| Property | Definition |
+| -------- | ---------- |
+| `supportedRegions`  | A record with domain codes as a key (regex) and a domain to redirect to as a value |
+| `defaultRegionCode` | The default region code(s) as regex. These are the regions supported by `defaultDomain`. When multiple codes are used the default will be the first code the default site eg. `AU,NZ` will treat `AU` as the default |
+| `defaultDomain`     | The website's main domain. This will act as a fallback for any unsupported regions |
+| `enablePathRedirect` | Will toggle adding a path suffix for a region such as `.com/au` or whether it should just be `.com` |
 
 ### Using this package
 
 The two main ways you can use this package are as follows:
-First off your website has a basic domain let's say `www.iamawesome.com` and you serve all content for all regions of the world here such as `www.iamawesome.com/us` or `www.iamawesome.com/au`. For this approach you should use the below method
+First off your website has a basic domain let's say `www.aligent.com.au` and you serve all content for all regions of the world here such as `www.aligent.com.au/au` or `www.aligent.com.au/nz`. For this approach you should use the below method
 
 ```
 redirectBehaviourOptions: {
-	defaultDomain: "www.iamawesome.com",
-	defaultRegionCode: "AU|US",
+	defaultDomain: "www.iamawesome.com/au",
+	defaultRegionCode: "AU,NZ",
 }
 ```
 
-Any region codes that are regexed to be `XX|YY` (note the pipe `|`) will automatically add the matching region as a path suffix to the url.
+Any region codes that are regexed to be `XX,YY` (note the comma `,`) will automatically add the matching region as a path suffix to the url.
 
-However perhaps you also have `www.iamawesome.co.nz`. How to redirect to a website that is different from the base domain? To achieve this, you can "hardcode" a domain for a region to use by using the `supportedRegions` value.
+However in order to redirect to a website that is different from the base domain such as `www.aligent.co.nz` you can "hardcode" a domain for a region to use by using the `supportedRegions` value.
 
 ```
 redirectBehaviourOptions: {
 	defaultDomain: "www.example.com",
-	defaultRegionCode: "AU|US",
+	defaultRegionCode: "AU,US",
 	supportedRegions: { "NZ": "www.example.co.nz" }
 }
 ```

--- a/packages/geoip-redirect/index.ts
+++ b/packages/geoip-redirect/index.ts
@@ -1,3 +1,6 @@
-import { RedirectFunction, RedirectFunctionOptions } from "./lib/redirect-construct";
+import {
+  RedirectFunction,
+  RedirectFunctionOptions,
+} from "./lib/redirect-construct";
 
 export { RedirectFunction, RedirectFunctionOptions };

--- a/packages/geoip-redirect/index.ts
+++ b/packages/geoip-redirect/index.ts
@@ -1,3 +1,3 @@
-import { RedirectFunction } from "./lib/redirect-construct";
+import { RedirectFunction, GeoIpRegion, RedirectFunctionOptions } from "./lib/redirect-construct";
 
-export { RedirectFunction };
+export { RedirectFunction, GeoIpRegion, RedirectFunctionOptions };

--- a/packages/geoip-redirect/index.ts
+++ b/packages/geoip-redirect/index.ts
@@ -1,3 +1,3 @@
-import { RedirectFunction, GeoIpRegion, RedirectFunctionOptions } from "./lib/redirect-construct";
+import { RedirectFunction, RedirectFunctionOptions } from "./lib/redirect-construct";
 
-export { RedirectFunction, GeoIpRegion, RedirectFunctionOptions };
+export { RedirectFunction, RedirectFunctionOptions };

--- a/packages/geoip-redirect/lib/handlers/redirect.ts
+++ b/packages/geoip-redirect/lib/handlers/redirect.ts
@@ -20,7 +20,7 @@ export const handler = async (
   options.defaultRegionCode = process.env.DEFAULT_REGION_CODE ?? "";
   const defaultRegion = options.defaultRegionCode.split("|")[0].toLowerCase();
   options.supportedRegions = {
-    ...process.env.SUPPORTED_REGIONS as Record<string, DomainOverwrite> ?? "{}",
+    ...process.env.SUPPORTED_REGIONS as Record<string, string> ?? "{}",
     ...{ [options.defaultRegionCode]: options.defaultDomain }
   };
 

--- a/packages/geoip-redirect/lib/handlers/redirect.ts
+++ b/packages/geoip-redirect/lib/handlers/redirect.ts
@@ -4,26 +4,31 @@ import {
   CloudFrontResponse,
   CloudFrontRequest,
 } from "aws-lambda";
-import { RedirectFunctionOptions } from "../redirect-construct";
 
-const options: RedirectFunctionOptions = {
-  defaultDomain: "",
-  defaultRegionCode: "",
-  supportedRegions: { "": "" },
+const options = {
+  defaultDomain: process.env.DEFAULT_DOMAIN ?? "",
+  defaultRegionCode: process.env.DEFAULT_REGION_CODE ?? "",
+  supportedRegions: { "": "" } as Record<string, string>,
+  enablePathRedirect:
+    process.env.ENABLE_PATH_REDIRECT === "true" ? true : false,
 };
+
+options.supportedRegions = {
+  ...(JSON.parse(
+    JSON.stringify(process.env.SUPPORTED_REGIONS ?? "{}")
+  ) as Record<string, string>),
+  ...{ [options.defaultRegionCode]: options.defaultDomain },
+};
+
+const defaultRegion = options.defaultRegionCode.split(",")[0].toLowerCase();
 
 export const handler = async (
   event: CloudFrontRequestEvent
 ): Promise<CloudFrontResponse | CloudFrontRequest> => {
   const request = event.Records[0].cf.request;
-  options.defaultDomain = process.env.DEFAULT_DOMAIN ?? "";
-  options.defaultRegionCode = process.env.DEFAULT_REGION_CODE ?? "";
-  const defaultRegion = options.defaultRegionCode.split("|")[0].toLowerCase();
-  options.supportedRegions = {
-    ...((process.env.SUPPORTED_REGIONS as Record<string, string>) ?? "{}"),
-    ...{ [options.defaultRegionCode]: options.defaultDomain },
-  };
 
+  // this block takes the records in supportedRegions and converts the keys to lowercase.
+  // doesn't change the functionality but makes it easier for users to not worry about being case sensitive
   if (options.supportedRegions) {
     options.supportedRegions = Object.keys(options.supportedRegions).reduce(
       (newRecord, key) => {
@@ -32,7 +37,7 @@ export const handler = async (
           : "";
         return newRecord;
       },
-      {}
+      {} // keeps the value for the corresponding key
     );
   }
 
@@ -41,19 +46,22 @@ export const handler = async (
     const countryCode =
       request.headers["cloudfront-viewer-country"][0].value.toLowerCase();
     // Check if any key in supportedSubRegions matches the countryCode using regex
-    const recordKey = Object.keys(options.supportedRegions)
-      .find(pattern =>
-        new RegExp(`^(${pattern.toLowerCase()})$`).test(countryCode)
+    const recordKey = Object.keys(options.supportedRegions || {})
+      .find(recordRegionCode =>
+        recordRegionCode.toLowerCase().includes(countryCode)
       )
       ?.toLowerCase();
+    // if theres a record key it means a redirect domain was hardcoded in the value we can get the value of a record using record[key]
     if (recordKey) {
       redirectURL = `https://${options.supportedRegions[recordKey]}/`;
-      if (recordKey.includes("|"))
-        redirectURL = redirectURL + countryCode.toLowerCase();
+      // If the key includes multiple domains, we additionally want to redirect to the country path of the user
+      if (recordKey.includes(",")) redirectURL += countryCode.toLowerCase();
     } else {
-      redirectURL = `${redirectURL}${defaultRegion}${request.uri}`;
+      // otherwise direct to the default domain
+      redirectURL = `${redirectURL}${request.uri}`;
+      if (options.enablePathRedirect)
+        redirectURL = `${redirectURL}${defaultRegion}${request.uri}`;
     }
-
     return {
       status: "302",
       statusDescription: "Found",

--- a/packages/geoip-redirect/lib/handlers/redirect.ts
+++ b/packages/geoip-redirect/lib/handlers/redirect.ts
@@ -7,7 +7,7 @@ import {
 
 const options = {
   defaultDomain: process.env.DEFAULT_DOMAIN ?? "",
-  defaultRegionCode: process.env.DEFAULT_REGION_CODE ?? "",
+  defaultRegionCodes: process.env.DEFAULT_REGION_CODES?.split(",") ?? [],
   supportedRegions: { "": "" } as Record<string, string>,
   enablePathRedirect:
     process.env.ENABLE_PATH_REDIRECT === "true" ? true : false,
@@ -17,10 +17,12 @@ options.supportedRegions = {
   ...(JSON.parse(
     JSON.stringify(process.env.SUPPORTED_REGIONS ?? "{}")
   ) as Record<string, string>),
-  ...{ [options.defaultRegionCode]: options.defaultDomain },
+  ...Object.fromEntries(
+    options.defaultRegionCodes.map(code => [code, options.defaultDomain])
+  ),
 };
 
-const defaultRegion = options.defaultRegionCode.split(",")[0].toLowerCase();
+const defaultRegion = options.defaultRegionCodes[0].toLowerCase();
 
 export const handler = async (
   event: CloudFrontRequestEvent

--- a/packages/geoip-redirect/lib/handlers/redirect.ts
+++ b/packages/geoip-redirect/lib/handlers/redirect.ts
@@ -7,27 +7,53 @@ import {
 
 import { GeoIpRegion } from '../redirect-construct'
 
-const DEFAULT_DOMAIN: string = process.env.DEFAULT_DOMAIN!;
-const DEFAULT_REGION: string = process.env.DEFAULT_REGION!;
-const SUPPORTED_REGIONS: GeoIpRegion[] = process.env.SUPPORTED_REGIONS ? JSON.parse(process.env.SUPPORTED_REGIONS) : [{
-  regionDomain: DEFAULT_DOMAIN,
-  supportedSubRegions: { DEFAULT_REGION: { absoluteDomain: DEFAULT_DOMAIN, regionPath: DEFAULT_REGION.toLowerCase() } },
-}];
+
 
 export const handler = async (
   event: CloudFrontRequestEvent
 ): Promise<CloudFrontResponse | CloudFrontRequest> => {
+  console.log('====================================');
+  console.log(process.env.DEFAULT_DOMAIN, process.env.DEFAULT_REGION_CODE, process.env.SUPPORTED_REGIONS);
+  console.log('====================================');
+  const DEFAULT_DOMAIN: string = process.env.DEFAULT_DOMAIN ?? "";
+  const DEFAULT_REGION_CODE: string = process.env.DEFAULT_REGION_CODE ?? "";
+  const SUPPORTED_REGIONS: GeoIpRegion[] = process.env.SUPPORTED_REGIONS ? JSON.parse(process.env.SUPPORTED_REGIONS) as GeoIpRegion[] : [{ // this seems to not be correct, not passing as string!
+    regionDomain: DEFAULT_DOMAIN,
+    supportedSubRegions: { DEFAULT_REGION_CODE: { absoluteDomain: DEFAULT_DOMAIN, regionPath: DEFAULT_REGION_CODE.toLowerCase() } },
+  }];
   const request = event.Records[0].cf.request;
 
   let redirectURL = `https://${DEFAULT_DOMAIN}/`;
   if (request.headers["cloudfront-viewer-country"]) {
+    console.log('====================================');
+    console.log(request.headers["cloudfront-viewer-country"]);
+    console.log('====================================');
     const countryCode = request.headers["cloudfront-viewer-country"][0].value;
+    const matchingRegion = SUPPORTED_REGIONS.find(region => {
+      // Check if any key in supportedSubRegions matches the countryCode using regex
+      return Object.keys(region.supportedSubRegions).some(pattern =>
+        new RegExp(`^(${pattern})$`).test(countryCode)
+      );
+    });
+
+    if (matchingRegion) {
+      const matchedKey = Object.keys(matchingRegion.supportedSubRegions).find(pattern =>
+        new RegExp(`^(${pattern})$`).test(countryCode)
+      );
+      if (matchedKey) {
+        const regionValue = matchingRegion.supportedSubRegions[matchedKey];
+      }
+      console.log('====================================');
+      console.log(matchedKey);
+      console.log('====================================');
+    }
+
     const geoIpRegion = SUPPORTED_REGIONS.find(region => countryCode in region.supportedSubRegions)
     if (geoIpRegion) {
       const subRegion = geoIpRegion.supportedSubRegions[countryCode]
       redirectURL = subRegion ? `${subRegion}${request.uri}` : `${geoIpRegion.regionDomain}/${countryCode.toLowerCase()}${request.uri}`;
     } else {
-      redirectURL = `${redirectURL}/${DEFAULT_REGION.toLowerCase()}${request.uri}`;
+      redirectURL = `${redirectURL}/${DEFAULT_REGION_CODE.toLowerCase()}${request.uri}`;
     }
 
     return {

--- a/packages/geoip-redirect/lib/handlers/redirect.ts
+++ b/packages/geoip-redirect/lib/handlers/redirect.ts
@@ -4,13 +4,13 @@ import {
   CloudFrontResponse,
   CloudFrontRequest,
 } from "aws-lambda";
-import { DomainOverwrite, RedirectFunctionOptions } from '../redirect-construct'
+import { RedirectFunctionOptions } from "../redirect-construct";
 
 const options: RedirectFunctionOptions = {
-  defaultDomain: '',
-  defaultRegionCode: '',
-  supportedRegions: { '': '' }
-}
+  defaultDomain: "",
+  defaultRegionCode: "",
+  supportedRegions: { "": "" },
+};
 
 export const handler = async (
   event: CloudFrontRequestEvent
@@ -20,30 +20,38 @@ export const handler = async (
   options.defaultRegionCode = process.env.DEFAULT_REGION_CODE ?? "";
   const defaultRegion = options.defaultRegionCode.split("|")[0].toLowerCase();
   options.supportedRegions = {
-    ...process.env.SUPPORTED_REGIONS as Record<string, string> ?? "{}",
-    ...{ [options.defaultRegionCode]: options.defaultDomain }
+    ...((process.env.SUPPORTED_REGIONS as Record<string, string>) ?? "{}"),
+    ...{ [options.defaultRegionCode]: options.defaultDomain },
   };
 
   if (options.supportedRegions) {
-    options.supportedRegions = Object.keys(options.supportedRegions).reduce((newRecord, key) => {
-      newRecord[key.toLowerCase()] = options.supportedRegions ? options.supportedRegions[key] : "";
-      return newRecord;
-    }, {});
+    options.supportedRegions = Object.keys(options.supportedRegions).reduce(
+      (newRecord, key) => {
+        newRecord[key.toLowerCase()] = options.supportedRegions
+          ? options.supportedRegions[key]
+          : "";
+        return newRecord;
+      },
+      {}
+    );
   }
 
   let redirectURL = `https://${options.defaultDomain}/`;
   if (request.headers["cloudfront-viewer-country"]) {
-    const countryCode = request.headers["cloudfront-viewer-country"][0].value.toLowerCase();
+    const countryCode =
+      request.headers["cloudfront-viewer-country"][0].value.toLowerCase();
     // Check if any key in supportedSubRegions matches the countryCode using regex
-    const recordKey = Object.keys(options.supportedRegions).find(pattern =>
-      new RegExp(`^(${pattern.toLowerCase()})$`).test(countryCode)
-    )?.toLowerCase();
+    const recordKey = Object.keys(options.supportedRegions)
+      .find(pattern =>
+        new RegExp(`^(${pattern.toLowerCase()})$`).test(countryCode)
+      )
+      ?.toLowerCase();
     if (recordKey) {
       redirectURL = `https://${options.supportedRegions[recordKey]}/`;
-      if (recordKey.includes('|'))
-        redirectURL = redirectURL + countryCode.toLowerCase()
+      if (recordKey.includes("|"))
+        redirectURL = redirectURL + countryCode.toLowerCase();
     } else {
-      redirectURL = `${redirectURL}${defaultRegion}${request.uri}`
+      redirectURL = `${redirectURL}${defaultRegion}${request.uri}`;
     }
 
     return {
@@ -53,7 +61,7 @@ export const handler = async (
         location: [
           {
             key: "Location",
-            value: redirectURL.replace('/index.html', ''),
+            value: redirectURL.replace("/index.html", ""),
           },
         ],
       },

--- a/packages/geoip-redirect/lib/handlers/redirect.ts
+++ b/packages/geoip-redirect/lib/handlers/redirect.ts
@@ -4,39 +4,46 @@ import {
   CloudFrontResponse,
   CloudFrontRequest,
 } from "aws-lambda";
+import { DomainOverwrite, RedirectFunctionOptions } from '../redirect-construct'
 
-import { GeoIpRegion } from '../redirect-construct'
-
-
+const options: RedirectFunctionOptions = {
+  defaultDomain: '',
+  defaultRegionCode: '',
+  supportedRegions: { '': '' }
+}
 
 export const handler = async (
   event: CloudFrontRequestEvent
 ): Promise<CloudFrontResponse | CloudFrontRequest> => {
-  const DEFAULT_DOMAIN: string = process.env.DEFAULT_DOMAIN ?? "";
-  const DEFAULT_REGION_CODE: string = process.env.DEFAULT_REGION_CODE ?? "";
-  const SUPPORTED_REGIONS: GeoIpRegion[] = process.env.SUPPORTED_REGIONS as GeoIpRegion[] ?? [{ // this seems to not be correct, not passing as string!
-    regionDomain: DEFAULT_DOMAIN,
-    supportedSubRegions: { absoluteDomain: DEFAULT_DOMAIN, regionPath: DEFAULT_REGION_CODE.toLowerCase() },
-  }];
   const request = event.Records[0].cf.request;
+  options.defaultDomain = process.env.DEFAULT_DOMAIN ?? "";
+  options.defaultRegionCode = process.env.DEFAULT_REGION_CODE ?? "";
+  const defaultRegion = options.defaultRegionCode.split("|")[0].toLowerCase();
+  options.supportedRegions = {
+    ...process.env.SUPPORTED_REGIONS as Record<string, DomainOverwrite> ?? "{}",
+    ...{ [options.defaultRegionCode]: options.defaultDomain }
+  };
 
-  let redirectURL = `https://${DEFAULT_DOMAIN}/`;
+  if (options.supportedRegions) {
+    options.supportedRegions = Object.keys(options.supportedRegions).reduce((newRecord, key) => {
+      newRecord[key.toLowerCase()] = options.supportedRegions ? options.supportedRegions[key] : "";
+      return newRecord;
+    }, {});
+  }
+
+  let redirectURL = `https://${options.defaultDomain}/`;
   if (request.headers["cloudfront-viewer-country"]) {
-    const countryCode = request.headers["cloudfront-viewer-country"][0].value;
-    const matchingRegionURL = SUPPORTED_REGIONS.map(region => {
-      // Check if any key in supportedSubRegions matches the countryCode using regex
-      const recordKey = Object.keys(region.supportedSubRegions).find(pattern =>
-        new RegExp(`^(${pattern})$`).test(countryCode)
-      );
-      if (recordKey) {
-        return region.supportedSubRegions[recordKey]
-      }
-      return null
-    }).find((value) => value !== null);
-
-    redirectURL = `${redirectURL}${countryCode.toLowerCase()}${request.uri}`
-    if (matchingRegionURL) {
-      redirectURL = `https://${matchingRegionURL}${request.uri}`
+    const countryCode = request.headers["cloudfront-viewer-country"][0].value.toLowerCase();
+    // Check if any key in supportedSubRegions matches the countryCode using regex
+    const recordKey = Object.keys(options.supportedRegions).find(pattern =>
+      new RegExp(`^(${pattern.toLowerCase()})$`).test(countryCode)
+    )?.toLowerCase();
+    if (recordKey) {
+      redirectURL = `https://${options.supportedRegions[recordKey]}/`;
+      if (recordKey.includes('|'))
+        redirectURL = redirectURL + countryCode.toLowerCase()
+    } else {
+      redirectURL = `${redirectURL}${defaultRegion}${request.uri}`
     }
 
     return {

--- a/packages/geoip-redirect/lib/handlers/redirect.ts
+++ b/packages/geoip-redirect/lib/handlers/redirect.ts
@@ -12,48 +12,31 @@ import { GeoIpRegion } from '../redirect-construct'
 export const handler = async (
   event: CloudFrontRequestEvent
 ): Promise<CloudFrontResponse | CloudFrontRequest> => {
-  console.log('====================================');
-  console.log(process.env.DEFAULT_DOMAIN, process.env.DEFAULT_REGION_CODE, process.env.SUPPORTED_REGIONS);
-  console.log('====================================');
   const DEFAULT_DOMAIN: string = process.env.DEFAULT_DOMAIN ?? "";
   const DEFAULT_REGION_CODE: string = process.env.DEFAULT_REGION_CODE ?? "";
-  const SUPPORTED_REGIONS: GeoIpRegion[] = process.env.SUPPORTED_REGIONS ? JSON.parse(process.env.SUPPORTED_REGIONS) as GeoIpRegion[] : [{ // this seems to not be correct, not passing as string!
+  const SUPPORTED_REGIONS: GeoIpRegion[] = process.env.SUPPORTED_REGIONS as GeoIpRegion[] ?? [{ // this seems to not be correct, not passing as string!
     regionDomain: DEFAULT_DOMAIN,
-    supportedSubRegions: { DEFAULT_REGION_CODE: { absoluteDomain: DEFAULT_DOMAIN, regionPath: DEFAULT_REGION_CODE.toLowerCase() } },
+    supportedSubRegions: { absoluteDomain: DEFAULT_DOMAIN, regionPath: DEFAULT_REGION_CODE.toLowerCase() },
   }];
   const request = event.Records[0].cf.request;
 
   let redirectURL = `https://${DEFAULT_DOMAIN}/`;
   if (request.headers["cloudfront-viewer-country"]) {
-    console.log('====================================');
-    console.log(request.headers["cloudfront-viewer-country"]);
-    console.log('====================================');
     const countryCode = request.headers["cloudfront-viewer-country"][0].value;
-    const matchingRegion = SUPPORTED_REGIONS.find(region => {
+    const matchingRegionURL = SUPPORTED_REGIONS.map(region => {
       // Check if any key in supportedSubRegions matches the countryCode using regex
-      return Object.keys(region.supportedSubRegions).some(pattern =>
+      const recordKey = Object.keys(region.supportedSubRegions).find(pattern =>
         new RegExp(`^(${pattern})$`).test(countryCode)
       );
-    });
-
-    if (matchingRegion) {
-      const matchedKey = Object.keys(matchingRegion.supportedSubRegions).find(pattern =>
-        new RegExp(`^(${pattern})$`).test(countryCode)
-      );
-      if (matchedKey) {
-        const regionValue = matchingRegion.supportedSubRegions[matchedKey];
+      if (recordKey) {
+        return region.supportedSubRegions[recordKey]
       }
-      console.log('====================================');
-      console.log(matchedKey);
-      console.log('====================================');
-    }
+      return null
+    }).find((value) => value !== null);
 
-    const geoIpRegion = SUPPORTED_REGIONS.find(region => countryCode in region.supportedSubRegions)
-    if (geoIpRegion) {
-      const subRegion = geoIpRegion.supportedSubRegions[countryCode]
-      redirectURL = subRegion ? `${subRegion}${request.uri}` : `${geoIpRegion.regionDomain}/${countryCode.toLowerCase()}${request.uri}`;
-    } else {
-      redirectURL = `${redirectURL}/${DEFAULT_REGION_CODE.toLowerCase()}${request.uri}`;
+    redirectURL = `${redirectURL}${countryCode.toLowerCase()}${request.uri}`
+    if (matchingRegionURL) {
+      redirectURL = `https://${matchingRegionURL}${request.uri}`
     }
 
     return {
@@ -63,7 +46,7 @@ export const handler = async (
         location: [
           {
             key: "Location",
-            value: redirectURL,
+            value: redirectURL.replace('/index.html', ''),
           },
         ],
       },

--- a/packages/geoip-redirect/lib/handlers/redirect.ts
+++ b/packages/geoip-redirect/lib/handlers/redirect.ts
@@ -69,7 +69,7 @@ export const handler = async (
         location: [
           {
             key: "Location",
-            value: redirectURL.replace("/index.html", ""),
+            value: redirectURL,
           },
         ],
       },

--- a/packages/geoip-redirect/lib/redirect-construct.ts
+++ b/packages/geoip-redirect/lib/redirect-construct.ts
@@ -48,9 +48,14 @@ export class RedirectFunction extends Construct {
             local: new Esbuild({
               entryPoints: [join(__dirname, "handlers/redirect.ts")],
               define: {
-                "process.env.DEFAULT_DOMAIN": JSON.stringify(options.defaultDomain),
-                "process.env.DEFAULT_REGION_CODE": JSON.stringify(options.defaultRegionCode.toLowerCase()),
-                "process.env.SUPPORTED_REGIONS": JSON.stringify(options.supportedRegions) ?? "{}"
+                "process.env.DEFAULT_DOMAIN": JSON.stringify(
+                  options.defaultDomain
+                ),
+                "process.env.DEFAULT_REGION_CODE": JSON.stringify(
+                  options.defaultRegionCode.toLowerCase()
+                ),
+                "process.env.SUPPORTED_REGIONS":
+                  JSON.stringify(options.supportedRegions) ?? "{}",
               },
             }),
           },

--- a/packages/geoip-redirect/lib/redirect-construct.ts
+++ b/packages/geoip-redirect/lib/redirect-construct.ts
@@ -59,8 +59,8 @@ export class RedirectFunction extends Construct {
                 "process.env.DEFAULT_DOMAIN": JSON.stringify(
                   options.defaultDomain
                 ),
-                "process.env.DEFAULT_REGION_CODE": JSON.stringify(
-                  options.defaultRegionCodes.join(",")
+                "process.env.DEFAULT_REGION_CODES": JSON.stringify(
+                  options.defaultRegionCodes
                 ).toLowerCase(),
                 "process.env.SUPPORTED_REGIONS": JSON.stringify(
                   options.supportedRegions

--- a/packages/geoip-redirect/lib/redirect-construct.ts
+++ b/packages/geoip-redirect/lib/redirect-construct.ts
@@ -43,9 +43,9 @@ export class RedirectFunction extends Construct {
             local: new Esbuild({
               entryPoints: [join(__dirname, "handlers/redirect.ts")],
               define: {
-                "process.env.DEFAULT_DOMAIN": options.defaultDomain,
-                "process.env.DEFAULT_REGION": options.defaultRegionCode,
-                "process.env.SUPPORTED_REGIONS":
+                "process.env.DEFAULT_DOMAIN": JSON.stringify(options.defaultDomain),
+                "process.env.DEFAULT_REGION_CODE": JSON.stringify(options.defaultRegionCode),
+                "process.env.SUPPORTED_REGIONS": // find out if this is passing as string or not, cloudW says not
                   JSON.stringify(options.supportedRegions)
               },
             }),
@@ -58,7 +58,7 @@ export class RedirectFunction extends Construct {
   }
 
   public getFunctionVersion(): IVersion {
-    return Version.fromVersionArn(
+    return Version.fromVersionArn( // SEE THE README ON YOUR DESKTOP (AND DELETE THESE COMMENTS)
       this,
       "redirect-fn-version",
       this.edgeFunction.currentVersion.edgeArn

--- a/packages/geoip-redirect/lib/redirect-construct.ts
+++ b/packages/geoip-redirect/lib/redirect-construct.ts
@@ -17,7 +17,7 @@ export interface RedirectFunctionOptions {
   /**
    * Regex for supported domain paths on the default domain eg .com/au
    */
-  defaultRegionCode: string;
+  defaultRegionCodes: string[];
   /**
    * Default domain to redirect to unless otherwise specified.
    */
@@ -60,13 +60,13 @@ export class RedirectFunction extends Construct {
                   options.defaultDomain
                 ),
                 "process.env.DEFAULT_REGION_CODE": JSON.stringify(
-                  options.defaultRegionCode
+                  options.defaultRegionCodes.join(",")
                 ).toLowerCase(),
                 "process.env.SUPPORTED_REGIONS": JSON.stringify(
                   options.supportedRegions
                 )?.toLowerCase(),
                 "process.env.ENABLE_PATH_REDIRECT": JSON.stringify(
-                  options.enablePathRedirect
+                  options.enablePathRedirect ?? false
                 )?.toLowerCase(),
               },
             }),

--- a/packages/geoip-redirect/lib/redirect-construct.ts
+++ b/packages/geoip-redirect/lib/redirect-construct.ts
@@ -22,6 +22,11 @@ export interface RedirectFunctionOptions {
    * Default domain to redirect to unless otherwise specified.
    */
   defaultDomain: string;
+  /**
+   * Toggle whether to use a path suffix for a region such as `.com/au` or just `.com`  .
+   * @default false
+   */
+  enablePathRedirect?: boolean;
 }
 
 export class RedirectFunction extends Construct {
@@ -46,16 +51,23 @@ export class RedirectFunction extends Construct {
             command,
             image: DockerImage.fromRegistry("busybox"),
             local: new Esbuild({
+              minify: false,
+              minifySyntax: false,
+              minifyWhitespace: false,
               entryPoints: [join(__dirname, "handlers/redirect.ts")],
               define: {
                 "process.env.DEFAULT_DOMAIN": JSON.stringify(
                   options.defaultDomain
                 ),
                 "process.env.DEFAULT_REGION_CODE": JSON.stringify(
-                  options.defaultRegionCode.toLowerCase()
-                ),
-                "process.env.SUPPORTED_REGIONS":
-                  JSON.stringify(options.supportedRegions) ?? "{}",
+                  options.defaultRegionCode
+                ).toLowerCase(),
+                "process.env.SUPPORTED_REGIONS": JSON.stringify(
+                  options.supportedRegions
+                )?.toLowerCase(),
+                "process.env.ENABLE_PATH_REDIRECT": JSON.stringify(
+                  options.enablePathRedirect
+                )?.toLowerCase(),
               },
             }),
           },

--- a/packages/geoip-redirect/lib/redirect-construct.ts
+++ b/packages/geoip-redirect/lib/redirect-construct.ts
@@ -5,8 +5,6 @@ import { Construct } from "constructs";
 import { join } from "path";
 import { Esbuild } from "@aligent/cdk-esbuild";
 
-export type DomainOverwrite = string | null
-
 /**
  * The default region, domain, and other supported regions for a website to redirect to.
  */
@@ -15,7 +13,7 @@ export interface RedirectFunctionOptions {
    * Regex formatted string to match region codes and redirect to the DomainOverwrite destination.
    * @default undefined
    */
-  supportedRegions?: Record<string, DomainOverwrite>;
+  supportedRegions?: Record<string, string>;
   /**
    * Regex for supported domain paths on the default domain eg .com/au
    */
@@ -48,10 +46,6 @@ export class RedirectFunction extends Construct {
             command,
             image: DockerImage.fromRegistry("busybox"),
             local: new Esbuild({
-
-              minify: false,
-              minifyWhitespace: false,
-              minifySyntax: false,
               entryPoints: [join(__dirname, "handlers/redirect.ts")],
               define: {
                 "process.env.DEFAULT_DOMAIN": JSON.stringify(options.defaultDomain),
@@ -68,7 +62,7 @@ export class RedirectFunction extends Construct {
   }
 
   public getFunctionVersion(): IVersion {
-    return Version.fromVersionArn( // SEE THE README ON YOUR DESKTOP (AND DELETE THESE COMMENTS)
+    return Version.fromVersionArn(
       this,
       "redirect-fn-version",
       this.edgeFunction.currentVersion.edgeArn

--- a/packages/geoip-redirect/lib/redirect-construct.ts
+++ b/packages/geoip-redirect/lib/redirect-construct.ts
@@ -5,17 +5,24 @@ import { Construct } from "constructs";
 import { join } from "path";
 import { Esbuild } from "@aligent/cdk-esbuild";
 
-export interface GeoIpRegion {
-  // The domain that services a region (www.example.com for US/CA www.example.com.au for AU/NZ)
-  regionDomain: string;
-  // Case-sensitive regular expression matching cloudfront-viewer-country
-  supportedSubRegions: Record<string, string | null>;
-} // add an aboslute redirect URL such as yd.co.nz for eg
+export type DomainOverwrite = string | null
 
+/**
+ * The default region, domain, and other supported regions for a website to redirect to.
+ */
 export interface RedirectFunctionOptions {
-  supportedRegions: GeoIpRegion[]
-  // default region code to use when not matched
+  /**
+   * Regex formatted string to match region codes and redirect to the DomainOverwrite destination.
+   * @default undefined
+   */
+  supportedRegions?: Record<string, DomainOverwrite>;
+  /**
+   * Regex for supported domain paths on the default domain eg .com/au
+   */
   defaultRegionCode: string;
+  /**
+   * Default domain to redirect to unless otherwise specified.
+   */
   defaultDomain: string;
 }
 
@@ -48,9 +55,8 @@ export class RedirectFunction extends Construct {
               entryPoints: [join(__dirname, "handlers/redirect.ts")],
               define: {
                 "process.env.DEFAULT_DOMAIN": JSON.stringify(options.defaultDomain),
-                "process.env.DEFAULT_REGION_CODE": JSON.stringify(options.defaultRegionCode),
-                "process.env.SUPPORTED_REGIONS": // find out if this is passing as string or not, cloudW says not
-                  JSON.stringify(options.supportedRegions)
+                "process.env.DEFAULT_REGION_CODE": JSON.stringify(options.defaultRegionCode.toLowerCase()),
+                "process.env.SUPPORTED_REGIONS": JSON.stringify(options.supportedRegions) ?? "{}"
               },
             }),
           },

--- a/packages/geoip-redirect/lib/redirect-construct.ts
+++ b/packages/geoip-redirect/lib/redirect-construct.ts
@@ -9,7 +9,7 @@ export interface GeoIpRegion {
   // The domain that services a region (www.example.com for US/CA www.example.com.au for AU/NZ)
   regionDomain: string;
   // Case-sensitive regular expression matching cloudfront-viewer-country
-  supportedSubRegions: Record<string, string | undefined>;
+  supportedSubRegions: Record<string, string | null>;
 } // add an aboslute redirect URL such as yd.co.nz for eg
 
 export interface RedirectFunctionOptions {
@@ -41,6 +41,10 @@ export class RedirectFunction extends Construct {
             command,
             image: DockerImage.fromRegistry("busybox"),
             local: new Esbuild({
+
+              minify: false,
+              minifyWhitespace: false,
+              minifySyntax: false,
               entryPoints: [join(__dirname, "handlers/redirect.ts")],
               define: {
                 "process.env.DEFAULT_DOMAIN": JSON.stringify(options.defaultDomain),

--- a/packages/geoip-redirect/lib/redirect-construct.ts
+++ b/packages/geoip-redirect/lib/redirect-construct.ts
@@ -5,12 +5,18 @@ import { Construct } from "constructs";
 import { join } from "path";
 import { Esbuild } from "@aligent/cdk-esbuild";
 
-export interface RedirectFunctionOptions {
-  redirectHost: string;
+export interface GeoIpRegion {
+  // The domain that services a region (www.example.com for US/CA www.example.com.au for AU/NZ)
+  regionDomain: string;
   // Case-sensitive regular expression matching cloudfront-viewer-country
-  supportedRegionsExpression: string;
+  supportedSubRegions: Record<string, string | undefined>;
+} // add an aboslute redirect URL such as yd.co.nz for eg
+
+export interface RedirectFunctionOptions {
+  supportedRegions: GeoIpRegion[]
   // default region code to use when not matched
-  defaultRegion: string;
+  defaultRegionCode: string;
+  defaultDomain: string;
 }
 
 export class RedirectFunction extends Construct {
@@ -37,10 +43,10 @@ export class RedirectFunction extends Construct {
             local: new Esbuild({
               entryPoints: [join(__dirname, "handlers/redirect.ts")],
               define: {
-                "process.env.REDIRECT_HOST": options.redirectHost,
+                "process.env.DEFAULT_DOMAIN": options.defaultDomain,
+                "process.env.DEFAULT_REGION": options.defaultRegionCode,
                 "process.env.SUPPORTED_REGIONS":
-                  options.supportedRegionsExpression,
-                "process.env.DEFAULT_REGION": options.defaultRegion,
+                  JSON.stringify(options.supportedRegions)
               },
             }),
           },


### PR DESCRIPTION
**Description of the proposed changes**  

* Created a new interface `RedirectFunctionOptions` to provide a better way to pass region codes and domains to redirect to.
* Changed the functional logic to allow for more than just path rewrites such as `.com/au`. You can now redirect directly to a site or to a path based rewrite.
* Added a README

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback