### PR TITLE
DO-1881 Enable Dependabot Automatic version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,101 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+# Dependabot processes patterns in groups sequentially, assigning dependencies to the first matching group and excluding them from subsequent groups. 
+# The wildcard group will capture dependencies that haven't matched any of the previous groups, ensuring no duplicates while acting as a fallback for unclassified updates.
+
+version: 2
+updates:
+  # NPM dependencies configuration
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "aligent/aligent-devops"
+    target-branch: "dependabot-test"
+    open-pull-requests-limit: 10
+    ignore:                    # Ignore major version updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:     
+      # AWS-related dependencies
+      aws:
+        patterns:
+          - "aws-cdk*"
+          - "@aws-sdk*"
+          - "@aws*"
+          - "@types/aws*"
+          - "constructs"
+
+      # Prerender-related dependencies
+      prerender:
+        patterns:
+          - "prerender*"
+
+      # Esbuild dependencies
+      esbuild:
+        patterns:
+          - "esbuild"
+          - "@aligent/cdk-esbuild"
+          - "@nx/esbuild*"
+
+      # Testing-related dependencies
+      testing-tools:
+        patterns:
+          - "jest"
+          - "@types/jest"
+          - "ts-jest"
+          - "@nx/jest*"
+
+      # Development tool dependencies
+      dev-tools:
+        patterns:
+          - "@nx/*"
+          - "eslint*"
+          - "prettier*"
+          - "@typescript-eslint/*"
+          - "@types/*"
+          - "ts-*"
+
+      # Core TypeScript updates
+      typescript:
+        patterns:
+          - "typescript"
+
+      # Catch-all group for unclassified dependencies
+      other-dependencies:
+        patterns:
+          - "*"
+
+  # Docker dependencies configuration
+  - package-ecosystem: "docker"       # Docker image dependencies.
+    directories:                      # Directories to scan for Dockerfile.
+      - "/packages/prerender-fargate/lib/prerender"
+      - "/packages/graphql-mesh-server/assets/nginx"
+    schedule:
+      interval: "weekly"
+    reviewers:                        # Reviewers for Docker image updates.    
+      - "aligent/aligent-devops"
+    target-branch: "dependabot-test"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      shared-docker-images:           # Groups all Docker image updates into a single PR.
+        patterns:
+          - "*"
+
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"                    # Monitors all workflows in the repository.
+    schedule:
+      interval: "weekly"
+    reviewers:                        # Reviewers for Docker image updates.    
+      - "aligent/aligent-devops"
+    target-branch: "dependabot-test"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
**Description of the proposed changes**  

To automate dependency version updates while ensuring that the pull requests (PRs) generated are meaningful and actionable, rather than creating unnecessary noise. This is to maintain secure and up-to-date dependencies in our codebase efficiently.

**Configuration Highlights**

1. Automatic version updates
- Dependabot will automatically generate pull requests for dependency updates weekly.
- Major version updates are   to avoid breaking changes; only minor updates and patches are allowed. For major upgrades, manual configuration changes will be required.

2. Target Branch
- All PRs are initially directed to the dependabot-test branch for evaluation.
- Once the configuration is validated and deemed appropriate, the target branch will be switched to main.

3. Default Reviewers
- The aligent/aligent-devops team is set as the default reviewer for all Dependabot PRs to ensure technical oversight.

4. Grouping and Dependency Categories
- Grouped into categories to streamline PRs and reduce clutter 

**Screenshots (if applicable)**  

![image-20250128-003600](https://github.com/user-attachments/assets/f3852d97-3dd3-40f6-961e-a206df7c81f1)

![image-20250128-003150](https://github.com/user-attachments/assets/1a72f34a-0964-4439-85a4-86c7c148fa9a)




**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback