### PR TITLE
chore: fix template injection vulnerability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch target
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+        run: git fetch origin ${{ env.PR_BASE_REF }}
 
       - name: Enable Corepack
         run: corepack enable
@@ -29,4 +29,7 @@ jobs:
       - name: Build all packages
         run: yarn nx run-many -t build
 
-      - run: yarn nx affected:lint --base=origin/${{ github.event.pull_request.base.ref }} --parallel --max-parallel=3 
+      - run: yarn nx affected:lint --base=origin/${{ env.PR_BASE_REF }} --parallel --max-parallel=3 
+
+    env:
+      PR_BASE_REF: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
**Description of the proposed changes**  

A GitHub Actions workflow step contains a template expression referencing potentially untrusted GitHub context fields. This may allow malicious input to be injected into shell commands, leading to a potential supply chain attack as tokens of the CI/CD pipeline could be exfiltrated.

The env block ensures GitHub Actions resolves the expression safely before passing it to the shell. This should avoid the above issue.

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback