### PR TITLE
HOTFIX: Ensure lambda code is not built and bundled

### DIFF
--- a/packages/header-change-detection/project.json
+++ b/packages/header-change-detection/project.json
@@ -9,7 +9,8 @@
       "options": {
         "main": "packages/header-change-detection/index.ts",
         "outputPath": "dist/header-change-detection",
-        "tsConfig": "packages/header-change-detection/tsconfig.app.json"
+        "tsConfig": "packages/header-change-detection/tsconfig.app.json",
+        "assets": ["packages/header-change-detection/lib/lambda/**"]
       },
       "dependsOn": ["merge-gitignore"]
     },

--- a/packages/header-change-detection/tsconfig.app.json
+++ b/packages/header-change-detection/tsconfig.app.json
@@ -5,6 +5,6 @@
     "module": "commonjs",
     "types": ["node"]
   },
-  "exclude": ["./jest.config.ts"],
+  "exclude": ["./jest.config.ts", "lib/lambda/**/*.ts"],
   "include": ["lib/**/*.ts", "index.ts"]
 }


### PR DESCRIPTION
------

**Description of the proposed changes**  

Build is currently failing with the below as the lambda code is being transpiled as part of the publishing step. This change will force the typescript file to be included in the final artifact so it can be built during the cdk synth step.

```
 [ERROR] Could not resolve "node_modules/@aligent/cdk-header-change-detection/lib/lambda/header-check.ts"
```

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback