### PR TITLE
Feature/DO-1834 Header Change Detection add HTTP status flags for custom behaviour for BigCommerce

### DIFF
--- a/packages/header-change-detection/README.md
+++ b/packages/header-change-detection/README.md
@@ -11,6 +11,7 @@ Creates a Lambda function that periodically scans security headers and sends the
 This service aims to comply with PCI DSS to cover the requirements outlined by section 11.6.1.
 
 **11.6.1**: A change- and tamper-detection mechanism is deployed as follows:
+
 > - To alert personnel to unauthorized modification (including indicators of compromise, changes, additions, and deletions) to the security-impacting HTTP headers and the script contents of payment pages as received by the consumer browser.
 > - The mechanism is configured to evaluate the received HTTP headers and payment pages.
 > - The mechanism functions are performed as follows:
@@ -47,18 +48,19 @@ import { Topic } from "aws-cdk-lib/aws-sns";
 import { HeaderChangeDetection } from "@aligent/cdk-header-change-detection";
 
 // Create a new SNS topic
-const topic = new Topic(this, 'Topic');
+const topic = new Topic(this, "Topic");
 const snsTopic = new SnsTopic(topic);
 
 // Pass the required props
-new HeaderChangeDetection(this, 'HeaderChangeDetection', { snsTopic });
+new HeaderChangeDetection(this, "HeaderChangeDetection", { snsTopic });
 ```
 
 ## Local development
 
 [NPM link](https://docs.npmjs.com/cli/v7/commands/npm-link) can be used to develop the module locally.
+
 1. Pull this repository locally
 2. `cd` into this repository
 3. run `npm link`
 4. `cd` into the downstream repo (target project, etc) and run `npm link '@aligent/cdk-header-change-detection'`
-The downstream repository should now include a symlink to this module. Allowing local changes to be tested before pushing. You may want to update the version notation of the package in the downstream repository's `package.json`.
+   The downstream repository should now include a symlink to this module. Allowing local changes to be tested before pushing. You may want to update the version notation of the package in the downstream repository's `package.json`.

--- a/packages/header-change-detection/lib/header-change-detection.ts
+++ b/packages/header-change-detection/lib/header-change-detection.ts
@@ -43,6 +43,13 @@ export interface HeaderChangeDetectionProps {
    * Optionally pass any rule properties
    */
   ruleProps?: Partial<RuleProps>;
+
+  /**
+   * Optionally accept HTTP status codes other than 200
+   *
+   * @default ["200"]
+   */
+  acceptedHttpStatus?: string[];
 }
 
 const command = [
@@ -108,6 +115,7 @@ export class HeaderChangeDetection extends Construct {
         HEADERS: headers.join(","),
         TABLE: table.tableName,
         TOPIC_ARN: props.snsTopic.topic.topicArn,
+        ACCEPTED_HTTP_STATUS: (props.acceptedHttpStatus || ["200"]).join(","),
       },
     });
 

--- a/packages/header-change-detection/lib/lambda/header-check.ts
+++ b/packages/header-change-detection/lib/lambda/header-check.ts
@@ -23,6 +23,13 @@ const DB_CLIENT = new DynamoDBClient(config);
 
 const securityHeaders = HEADERS?.split(",") || [];
 
+// Accept status 200 default
+const ACCEPTED_HTTP_STATUS = (process.env.ACCEPTED_HTTP_STATUS || "200")
+  .split(",")
+  .map(code => parseInt(code.trim(), 10));
+
+console.log("ACCEPTED_HTTP_STATUS:", ACCEPTED_HTTP_STATUS);
+
 type Headers = Map<string, string | undefined>;
 
 // A map of URLs and their headers
@@ -80,8 +87,12 @@ const fetchHeaders = async (urls: string[]): Promise<URLHeaders> => {
   // Make an axios request for each url
   await Promise.all(
     urls.map(url =>
-      axios.get(url).then(response => {
-        // Then get all the security headers from each response
+      axios.get(url, { validateStatus: () => true }).then(response => {
+        if (!ACCEPTED_HTTP_STATUS.includes(response.status)) {
+          console.warn(`Skipping ${url} — status ${response.status} not allowed`);
+          return;
+        }
+
         const headers: Headers = new Map<string, string | undefined>();
 
         Object.entries(response.headers).forEach(([headerName, value]) => {

--- a/packages/header-change-detection/lib/lambda/header-check.ts
+++ b/packages/header-change-detection/lib/lambda/header-check.ts
@@ -157,7 +157,7 @@ const updateStoredValues = async (
     if (value) {
       attributes[headerName] = {
         Value: {
-          S: value,
+          S: Array.isArray(value) ? value.join("; ") : value,
         },
         Action: "PUT",
       };

--- a/packages/header-change-detection/lib/lambda/header-check.ts
+++ b/packages/header-change-detection/lib/lambda/header-check.ts
@@ -89,7 +89,9 @@ const fetchHeaders = async (urls: string[]): Promise<URLHeaders> => {
     urls.map(url =>
       axios.get(url, { validateStatus: () => true }).then(response => {
         if (!ACCEPTED_HTTP_STATUS.includes(response.status)) {
-          console.warn(`Skipping ${url} — status ${response.status} not allowed`);
+          console.warn(
+            `Skipping ${url} — status ${response.status} not allowed`
+          );
           return;
         }
 


### PR DESCRIPTION
<!-- ⚠⚠ Please fill in as many sections as possible  -->
<!-- ⚠⚠ Sections that aren't applicable can be removed, or have "N/A" added under the heading --> 
<!-- ⚠⚠ Please remove leading underscores before filling in. They're only there to force Bitbucket to add a new line underneath each section --> 
<!-- ⚠⚠ This top section should be removed before clicking the Create Pull Request button -->

------

**Description of the proposed changes**  

- Update Aligent's Header Change Detection to accommodate BigCommerce checkout behavior
- Added props to have an ability to add custom HTTP statuses.
- Joined the URL Array to a single string before saving.

**Screenshots (if applicable)**  
Before the change
![image](https://github.com/user-attachments/assets/d47f90d6-76e1-4ecb-8224-3dc1ae2fd33d)

After the Change 
Test with added 406 status
![image](https://github.com/user-attachments/assets/02fb5e8c-f459-48b3-91a8-5f36fc7266ee)
Test without the 406
![image](https://github.com/user-attachments/assets/14a088ed-19b6-415b-b6e3-258de1e43f5c)


**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback