### PR TITLE
fix(ci): use GitHub Actions env syntax to reference PACKAGE and VERSION

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
         run: |
           git config --global user.name "Automated NPM Release"
           git config --global user.email "devops+npm-deploy@aligent.com.au"
-          echo "Publishing $PACKAGE @ $VERSION"
+          echo "Publishing ${{ env.PACKAGE }} @ ${{ env.VERSION }}"
           npm config set registry https://registry.npmjs.org/
-          yarn nx publish $PACKAGE --ver=$VERSION --tag=latest --verbose
+          yarn nx publish ${{ env.PACKAGE }} --ver=${{ env.VERSION }} --tag=latest --verbose
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Description of the proposed changes**  
* Correctly reference environment variables set via  using ${{ env.VAR }} instead of Bash-style $VAR, which is not available across steps. This fixes an issue where the release step failed due to undefined PACKAGE and VERSION variables.

**Screenshots (if applicable)**  

* 

**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback