### PR TITLE
feat DO-1856: add option for CPU scaling

### DIFF
--- a/packages/prerender-fargate/lib/prerender-fargate-options.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate-options.ts
@@ -206,7 +206,7 @@ export interface PrerenderFargateScalingOptions {
   unhealthyThresholdCount?: number;
   /**
    * The target average CPU load for auto scaling.
-   * @default - 10 
+   * @default - 10
    */
   targetUtilizationPercent?: number;
 }

--- a/packages/prerender-fargate/lib/prerender-fargate-options.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate-options.ts
@@ -204,6 +204,11 @@ export interface PrerenderFargateScalingOptions {
    * @default - 5
    */
   unhealthyThresholdCount?: number;
+  /**
+   * The target average CPU load for auto scaling.
+   * @default - 10 
+   */
+  targetUtilizationPercent?: number;
 }
 
 /**

--- a/packages/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate.ts
@@ -238,7 +238,7 @@ export class PrerenderFargate extends Construct {
       minCapacity: minInstanceCount || 1,
     });
     scaling.scaleOnCpuUtilization(`${prerenderName}-scaling`, {
-      targetUtilizationPercent: 50,
+      targetUtilizationPercent: prerenderFargateScalingOptions?.targetUtilizationPercent || 10,
       scaleInCooldown: Duration.seconds(
         prerenderFargateScalingOptions?.scaleInCooldown || 60
       ),

--- a/packages/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate.ts
@@ -238,7 +238,8 @@ export class PrerenderFargate extends Construct {
       minCapacity: minInstanceCount || 1,
     });
     scaling.scaleOnCpuUtilization(`${prerenderName}-scaling`, {
-      targetUtilizationPercent: prerenderFargateScalingOptions?.targetUtilizationPercent || 10,
+      targetUtilizationPercent:
+        prerenderFargateScalingOptions?.targetUtilizationPercent || 10,
       scaleInCooldown: Duration.seconds(
         prerenderFargateScalingOptions?.scaleInCooldown || 60
       ),


### PR DESCRIPTION
**Description of the proposed changes**  

* Allow easily overriding the `targetUtilizationPercent` value
* Change the default to much lower to actually scale with load. Prerender CPU load is quite bursty so an average CPU of 10% means it's under quite a bit of load. The max average I've seen is only 25% so the previously set 50% would never trigger.

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback