### PR TITLE
Removed set-cookie header, updated README

### DIFF
--- a/packages/geoip-redirect/README.md
+++ b/packages/geoip-redirect/README.md
@@ -23,7 +23,7 @@ interface RedirectFunctionOptions {
 | Property | Definition |
 | -------- | ---------- |
 | `supportedRegions`  | A record with domain codes as a key (regex) and a domain to redirect to as a value |
-| `defaultRegionCode` | The default region code(s) as regex. These are the regions supported by `defaultDomain`. When multiple codes are used the default will be the first code the default site eg. `AU,NZ` will treat `AU` as the default |
+| `defaultRegionCode` | The default region code(s) as regex. These are the regions supported by `defaultDomain`. When multiple codes are used the default will be the first code the default site eg. `["AU","NZ"]` will treat `AU` as the default |
 | `defaultDomain`     | The website's main domain. This will act as a fallback for any unsupported regions |
 | `enablePathRedirect` | Will toggle adding a path suffix for a region such as `.com/au` or whether it should just be `.com` |
 
@@ -34,20 +34,20 @@ First off your website has a basic domain let's say `www.aligent.com.au` and you
 
 ```
 redirectBehaviourOptions: {
-	defaultDomain: "www.iamawesome.com/au",
-	defaultRegionCode: "AU,NZ",
+	defaultDomain: "www.aligent.com/au",
+	defaultRegionCode: ["AU","NZ"],
 }
 ```
 
-Any region codes that are regexed to be `XX,YY` (note the comma `,`) will automatically add the matching region as a path suffix to the url.
+Any region codes that are in the array like: `["XX","YY"]` will automatically add the matching region as a path suffix to the url as lowercase.
 
 However in order to redirect to a website that is different from the base domain such as `www.aligent.co.nz` you can "hardcode" a domain for a region to use by using the `supportedRegions` value.
 
 ```
 redirectBehaviourOptions: {
-	defaultDomain: "www.example.com",
+	defaultDomain: "www.aligent.com",
 	defaultRegionCode: "AU,US",
-	supportedRegions: { "NZ": "www.example.co.nz" }
+	supportedRegions: { "NZ": "www.aligent.co.nz" }
 }
 ```
 

--- a/packages/header-change-detection/README.md
+++ b/packages/header-change-detection/README.md
@@ -35,7 +35,6 @@ By default, the following headers are monitored:
 - Referrer-Policy
 - Permission-Policy
 - Cache-Control
-- Set-Cookie
 
 ## Usage
 

--- a/packages/header-change-detection/lib/header-change-detection.ts
+++ b/packages/header-change-detection/lib/header-change-detection.ts
@@ -71,7 +71,6 @@ const defaultHeaders = [
   "referrer-policy",
   "permission-policy",
   "cache-control",
-  "set-cookie",
 ];
 
 export class HeaderChangeDetection extends Construct {


### PR DESCRIPTION
**Description of the proposed changes**  

* removed `set-cookie` header from the monitoring so that it's less annoying (it's not a security header so not needed to monitor as per PCI standards)
* also updated the GeoIP readme as a small fix to due to changing the logic and forgot to change readme

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback