### PR TITLE
chore: set dependabot to target main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       interval: "weekly"
     reviewers:
       - "aligent/aligent-devops"
-    target-branch: "dependabot-test"
+    target-branch: "main"
     open-pull-requests-limit: 10
     ignore:                    # Ignore major version updates
       - dependency-name: "*"
@@ -79,7 +79,7 @@ updates:
       interval: "weekly"
     reviewers:                        # Reviewers for Docker image updates.    
       - "aligent/aligent-devops"
-    target-branch: "dependabot-test"
+    target-branch: "main"
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "*"
@@ -97,5 +97,5 @@ updates:
       interval: "weekly"
     reviewers:                        # Reviewers for Docker image updates.    
       - "aligent/aligent-devops"
-    target-branch: "dependabot-test"
+    target-branch: "main"
     open-pull-requests-limit: 5


### PR DESCRIPTION
**Description of the proposed changes**  

* Make dependabot target main
* The PRs dependabot is making seem pretty good, happy to test by merging some in
* I've tested the a couple of the branches and they seem be working with builds

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback