### PR TITLE
Add multi site support

### DIFF
--- a/packages/graphql-mesh-server/README.md
+++ b/packages/graphql-mesh-server/README.md
@@ -5,3 +5,113 @@ A construct to host a [GraphQL Mesh](https://the-guild.dev/graphql/mesh) server 
 
 ## Deployment notifications
 If notificationArn is set this construct creates a CodeStar notification rule, SNS topic and Lambda function to receive notifications for codepipeline executions and forward them to another SNS topic. This is so that you can setup AWS Chatbot either in this account OR another account and forward the notifications there. 
+
+## Maintenance Mode
+A set of API Gateway functions are deployed by default as part of this construct that allow the mesh to be placed in / out of "Maintenance Mode" by creating JSON files on the filesystem shared by the mesh containers. 
+
+### Maintenance Mode API
+This API will enable / disable mainteance mode by toggling the file name on the shared filesystem from `maintenance.disabled` to `maintenance.enabled`. The file will contain a list of sites that should be in maintance mode. If ANY site is in maintenance mode the file will be named `maintenance.enabled`, it is then the responsiblity of the mesh to check the contents of that file to determine whether or not to allow the request.
+
+#### GET /maintenance
+Will return a list of sites currently in / out of maintenance mode.
+
+Example Response
+```json
+{
+    "sites": {
+        "example.com": true,
+        "example.com.au": false
+    }
+}
+```
+
+#### POST /maintenance 
+Will enable / disable maintenance mode for the requested sites and toggle the file name.
+
+Example Request
+```json
+{
+    "sites": {
+        "example.com": true,
+        "example.com.au": false
+    }
+}
+```
+
+Example Response
+```json
+{
+    "sites": {
+        "example.com": true,
+        "example.com.au": false
+    }
+}
+```
+
+### IP Whitelist API
+This API will add / update valid IPv4 or IPv6 addresses to the JSON files, so that the mesh can use these IPs to determine whether to allow specific requests through maintenance mode.
+
+#### GET /maintenance/whitelist/
+Returns the currently allowed IP addresses
+
+Example Response
+```json
+{
+    "whitelist": [
+        "127.0.0.1",
+        "192.168.0.1",
+        "8.8.8.8",
+        "0.0.0.0",
+        "2001:0db8::1",
+        "2001:4860:4860::8888",
+    ]
+}
+```
+
+#### POST /maintenance/whitelist/
+Update allowed IP addresses to only what is included in the payload.
+
+Example Request
+```json
+{
+    "whitelist": [
+        "127.0.0.1"
+    ]
+}
+```
+
+Example Response 
+```json
+{
+    "whitelist": [
+        "127.0.0.1"
+    ]
+}
+```
+
+#### PATCH /maintenance/whitelist/
+Add the provided IP addresses to the allowlist.
+
+Example Request
+```json
+{
+    "whitelist": [
+        "192.168.1.1"
+    ]
+}
+```
+
+Example Response
+```json
+{
+    "whitelist": [
+        "127.0.0.1",
+        "192.168.0.1",
+        "8.8.8.8",
+        "0.0.0.0",
+        "2001:0db8::1",
+        "2001:4860:4860::8888",
+        "192.168.1.1"
+    ]
+}
+```

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/lib/file.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/lib/file.ts
@@ -50,16 +50,14 @@ export const updateWhitelist = (whitelist: Array<string>): void => {
   setWhitelist(maintFile.whitelist.concat(whitelist));
 };
 
-export const getCurrentStatus = (): "disabled" | "enabled" => {
-  return inMaintenanceMode() ? "enabled" : "disabled";
-};
+export const updateMaintenanceStatus = (sites: Record<string, boolean>) => {
+  let maintFile = getMaintenanceFile();
+  maintFile.sites = sites;
+  writeFileSync(getFilePath(), JSON.stringify(maintFile), { encoding: "utf-8" });
+}
 
-export const inMaintenanceMode = (): boolean => {
-  return getFilePath().includes("enabled");
-};
-
-export const toggleMaintenanceStatus = () => {
-  const desiredStatus = inMaintenanceMode() ? "disabled" : "enabled";
+export const toggleMaintenanceStatus = (status: boolean) => {
+  const desiredStatus = status ? "enabled" : "disabled";
 
   renameSync(
     getFilePath(),

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/lib/file.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/lib/file.ts
@@ -26,7 +26,7 @@ export const getFilePath = (): string => {
   }
 
   // If the maintenance file wasn't found, create one
-  writeFileSync(PATHS[0], JSON.stringify({whitelist: [], sites: {}}));
+  writeFileSync(PATHS[0], JSON.stringify({ whitelist: [], sites: {} }));
   return PATHS[0];
 };
 
@@ -36,25 +36,31 @@ export const getMaintenanceFile = (): MaintenanceFile => {
 };
 
 export const setWhitelist = (whitelist: Array<string>): void => {
-  if (!validateIps(whitelist)) throw new Error("List of IP addresses is not valid");
-  let maintFile = getMaintenanceFile();
-  maintFile.whitelist = [...new Set(whitelist)]
+  if (!validateIps(whitelist))
+    throw new Error("List of IP addresses is not valid");
+  const maintFile = getMaintenanceFile();
+  maintFile.whitelist = [...new Set(whitelist)];
 
-  writeFileSync(getFilePath(), JSON.stringify(maintFile), { encoding: "utf-8" });
+  writeFileSync(getFilePath(), JSON.stringify(maintFile), {
+    encoding: "utf-8",
+  });
 };
 
 export const updateWhitelist = (whitelist: Array<string>): void => {
-  if (!validateIps(whitelist)) throw new Error("List of IP addresses is not valid");
+  if (!validateIps(whitelist))
+    throw new Error("List of IP addresses is not valid");
   const maintFile = getMaintenanceFile();
 
   setWhitelist(maintFile.whitelist.concat(whitelist));
 };
 
 export const updateMaintenanceStatus = (sites: Record<string, boolean>) => {
-  let maintFile = getMaintenanceFile();
+  const maintFile = getMaintenanceFile();
   maintFile.sites = sites;
-  writeFileSync(getFilePath(), JSON.stringify(maintFile), { encoding: "utf-8" });
-}
+  writeFileSync(getFilePath(), JSON.stringify(maintFile), {
+    encoding: "utf-8",
+  });
+};
 
 export const toggleMaintenanceStatus = (status: boolean) => {
   const desiredStatus = status ? "enabled" : "disabled";

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/lib/file.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/lib/file.ts
@@ -13,6 +13,11 @@ const PATHS = [
   `${MAINTENANCE_FILE_PATH}/${FILE_NAME}.enabled`,
 ];
 
+export interface MaintenanceFile {
+  whitelist: Array<string>;
+  sites: Record<string, boolean>;
+}
+
 export const getFilePath = (): string => {
   for (const path of PATHS) {
     if (existsSync(path)) {
@@ -21,26 +26,28 @@ export const getFilePath = (): string => {
   }
 
   // If the maintenance file wasn't found, create one
-  writeFileSync(PATHS[0], "");
+  writeFileSync(PATHS[0], JSON.stringify({whitelist: [], sites: {}}));
   return PATHS[0];
 };
 
-export const getFileContents = (): string => {
-  return readFileSync(getFilePath(), "utf-8");
+export const getMaintenanceFile = (): MaintenanceFile => {
+  const fileContents = readFileSync(getFilePath(), "utf-8");
+  return JSON.parse(fileContents) as MaintenanceFile;
 };
 
-export const setFileContents = (input: string): void => {
-  if (!validateIps(input)) throw new Error("List of IP addresses not valid");
-  const uniqueIps = [...new Set(input.split(","))].join(",");
+export const setWhitelist = (whitelist: Array<string>): void => {
+  if (!validateIps(whitelist)) throw new Error("List of IP addresses is not valid");
+  let maintFile = getMaintenanceFile();
+  maintFile.whitelist = [...new Set(whitelist)]
 
-  writeFileSync(getFilePath(), uniqueIps, { encoding: "utf-8" });
+  writeFileSync(getFilePath(), JSON.stringify(maintFile), { encoding: "utf-8" });
 };
 
-export const updateFileContents = (input: string): void => {
-  if (!input) throw new Error("Nothing to update.");
-  if (!validateIps(input)) throw new Error("List of IP addresses not valid");
+export const updateWhitelist = (whitelist: Array<string>): void => {
+  if (!validateIps(whitelist)) throw new Error("List of IP addresses is not valid");
+  const maintFile = getMaintenanceFile();
 
-  setFileContents(`${getFileContents()},${input}`);
+  setWhitelist(maintFile.whitelist.concat(whitelist));
 };
 
 export const getCurrentStatus = (): "disabled" | "enabled" => {
@@ -60,9 +67,8 @@ export const toggleMaintenanceStatus = () => {
   );
 };
 
-const validateIps = (ipList: string) => {
-  const ips = ipList.split(",");
+const validateIps = (ipList: Array<string>) => {
   return (
-    ips.find(ip => !IP_REGEX.test(ip) && !IP_V6_REGEX.test(ip)) === undefined
+    ipList.find(ip => !IP_REGEX.test(ip) && !IP_V6_REGEX.test(ip)) === undefined
   );
 };

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/maintenance.test.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/maintenance.test.ts
@@ -2,7 +2,7 @@
 import { cwd } from "process";
 import { handler } from "./maintenance";
 import { APIGatewayProxyEvent } from "aws-lambda";
-import { setWhitelist, updateMaintenanceStatus } from "./lib/file";
+import { updateMaintenanceStatus } from "./lib/file";
 import { existsSync, rmSync } from "fs";
 
 const createMockEvent = (
@@ -19,6 +19,7 @@ const createMockEvent = (
   queryStringParameters: null,
   multiValueQueryStringParameters: null,
   stageVariables: null,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   requestContext: {} as any,
   resource: "/",
 });

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/maintenance.test.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/maintenance.test.ts
@@ -1,67 +1,74 @@
 // handler.test.ts
-import { cwd } from 'process';
-import { handler } from './maintenance';
-import { APIGatewayProxyEvent } from 'aws-lambda';
-import { setWhitelist, updateMaintenanceStatus } from './lib/file';
-import { existsSync, rmSync } from 'fs';
+import { cwd } from "process";
+import { handler } from "./maintenance";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { setWhitelist, updateMaintenanceStatus } from "./lib/file";
+import { existsSync, rmSync } from "fs";
 
-const createMockEvent = (method: string, body?: string): APIGatewayProxyEvent => ({
+const createMockEvent = (
+  method: string,
+  body?: string
+): APIGatewayProxyEvent => ({
   body: body || null,
   headers: {},
   multiValueHeaders: {},
   httpMethod: method,
   isBase64Encoded: false,
-  path: '/',
+  path: "/",
   pathParameters: null,
   queryStringParameters: null,
   multiValueQueryStringParameters: null,
   stageVariables: null,
   requestContext: {} as any,
-  resource: '/',
+  resource: "/",
 });
-const mockSites = { 'example.com': false, 'example.com.au': false };
+const mockSites = { "example.com": false, "example.com.au": false };
 
-describe('Lambda handler', () => {
-    beforeAll(() => {
-        updateMaintenanceStatus(mockSites)
-    });
+describe("Lambda handler", () => {
+  beforeAll(() => {
+    updateMaintenanceStatus(mockSites);
+  });
 
-    it('should handle GET method', async () => {
-        const event = createMockEvent('GET');
-        const result = await handler(event);
+  it("should handle GET method", async () => {
+    const event = createMockEvent("GET");
+    const result = await handler(event);
 
-        expect(result.statusCode).toBe(200);
-        expect(JSON.parse(result.body)).toEqual({ sites: mockSites });
-    });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ sites: mockSites });
+  });
 
-    it("should handle POST'ing a enable single site", async () => {
-        const mockUpdate = { sites: { 'example.com': false, 'example.com.au': true } };
-        const event = createMockEvent('POST', JSON.stringify(mockUpdate));
-        const result = await handler(event);
+  it("should handle POST'ing a enable single site", async () => {
+    const mockUpdate = {
+      sites: { "example.com": false, "example.com.au": true },
+    };
+    const event = createMockEvent("POST", JSON.stringify(mockUpdate));
+    const result = await handler(event);
 
-        expect(result.statusCode).toBe(200);
-        expect(JSON.parse(result.body)).toEqual(mockUpdate);
-        expect(existsSync(`${cwd()}/maintenance.enabled`)).toBe(true);
-    });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual(mockUpdate);
+    expect(existsSync(`${cwd()}/maintenance.enabled`)).toBe(true);
+  });
 
-    it("should handle POST'ing a disable all sites", async () => {
-        expect(existsSync(`${cwd()}/maintenance.enabled`)).toBe(true);
-        const mockUpdate = { sites: { 'example.com': false, 'example.com.au': false } };
-        const event = createMockEvent('POST', JSON.stringify(mockUpdate));
-        const result = await handler(event);
+  it("should handle POST'ing a disable all sites", async () => {
+    expect(existsSync(`${cwd()}/maintenance.enabled`)).toBe(true);
+    const mockUpdate = {
+      sites: { "example.com": false, "example.com.au": false },
+    };
+    const event = createMockEvent("POST", JSON.stringify(mockUpdate));
+    const result = await handler(event);
 
-        expect(result.statusCode).toBe(200);
-        expect(JSON.parse(result.body)).toEqual(mockUpdate);
-        expect(existsSync(`${cwd()}/maintenance.disabled`)).toBe(true);
-    });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual(mockUpdate);
+    expect(existsSync(`${cwd()}/maintenance.disabled`)).toBe(true);
+  });
 
-    afterAll(() => {
-        if (existsSync(`${cwd()}/maintenance.enabled`)){
-            rmSync(`${cwd()}/maintenance.enabled`);
-        }
+  afterAll(() => {
+    if (existsSync(`${cwd()}/maintenance.enabled`)) {
+      rmSync(`${cwd()}/maintenance.enabled`);
+    }
 
-        if (existsSync(`${cwd()}/maintenance.disabled`)){
-            rmSync(`${cwd()}/maintenance.disabled`);
-        } 
-    });
+    if (existsSync(`${cwd()}/maintenance.disabled`)) {
+      rmSync(`${cwd()}/maintenance.disabled`);
+    }
+  });
 });

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/maintenance.test.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/maintenance.test.ts
@@ -1,0 +1,67 @@
+// handler.test.ts
+import { cwd } from 'process';
+import { handler } from './maintenance';
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { setWhitelist, updateMaintenanceStatus } from './lib/file';
+import { existsSync, rmSync } from 'fs';
+
+const createMockEvent = (method: string, body?: string): APIGatewayProxyEvent => ({
+  body: body || null,
+  headers: {},
+  multiValueHeaders: {},
+  httpMethod: method,
+  isBase64Encoded: false,
+  path: '/',
+  pathParameters: null,
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  stageVariables: null,
+  requestContext: {} as any,
+  resource: '/',
+});
+const mockSites = { 'example.com': false, 'example.com.au': false };
+
+describe('Lambda handler', () => {
+    beforeAll(() => {
+        updateMaintenanceStatus(mockSites)
+    });
+
+    it('should handle GET method', async () => {
+        const event = createMockEvent('GET');
+        const result = await handler(event);
+
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body)).toEqual({ sites: mockSites });
+    });
+
+    it("should handle POST'ing a enable single site", async () => {
+        const mockUpdate = { sites: { 'example.com': false, 'example.com.au': true } };
+        const event = createMockEvent('POST', JSON.stringify(mockUpdate));
+        const result = await handler(event);
+
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body)).toEqual(mockUpdate);
+        expect(existsSync(`${cwd()}/maintenance.enabled`)).toBe(true);
+    });
+
+    it("should handle POST'ing a disable all sites", async () => {
+        expect(existsSync(`${cwd()}/maintenance.enabled`)).toBe(true);
+        const mockUpdate = { sites: { 'example.com': false, 'example.com.au': false } };
+        const event = createMockEvent('POST', JSON.stringify(mockUpdate));
+        const result = await handler(event);
+
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body)).toEqual(mockUpdate);
+        expect(existsSync(`${cwd()}/maintenance.disabled`)).toBe(true);
+    });
+
+    afterAll(() => {
+        if (existsSync(`${cwd()}/maintenance.enabled`)){
+            rmSync(`${cwd()}/maintenance.enabled`);
+        }
+
+        if (existsSync(`${cwd()}/maintenance.disabled`)){
+            rmSync(`${cwd()}/maintenance.disabled`);
+        } 
+    });
+});

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/maintenance.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/maintenance.ts
@@ -1,51 +1,88 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import { getCurrentStatus, toggleMaintenanceStatus } from "./lib/file";
+import { getMaintenanceFile, toggleMaintenanceStatus, updateMaintenanceStatus } from "./lib/file";
 
 const MAINTENANCE_FILE_PATH = process.env.MAINTENANCE_FILE_PATH;
+
+interface MaintenanceRequest {
+  sites: Record<string, boolean>;
+}
+
+interface MaintenanceResponse {
+  sites: Record<string, boolean>;
+}
+
+interface MaintenanceErrorResponse {
+  error: string;
+}
+
+const parseBody = function (body: string|null): MaintenanceRequest {
+  if (!body) {
+    throw new Error('Update requests must contain a JSON body.');
+  }
+
+  let maintenanceRequest = JSON.parse(body);
+  
+  if (!('sites' in maintenanceRequest) || !(typeof maintenanceRequest.sites == 'object')) {
+    throw new Error('Maintenance request updates must contain a record of which sites to place in maintenance mode.');
+  }
+
+  return maintenanceRequest;
+}
 
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
-  if (!MAINTENANCE_FILE_PATH) throw new Error("a");
-  let body = "Method not implemented";
-  let status = 200;
+  if (!MAINTENANCE_FILE_PATH) throw new Error("Maintenance File path is missing.");
+  let status = 501;
+  let response: MaintenanceErrorResponse|MaintenanceResponse = {
+    error: "Method not implemented"
+  };
 
-  switch (event.httpMethod) {
-    case "GET":
-      body = getCurrentStatus();
-      break;
-    case "POST":
-      body = changeMaintenanceStatus(extractDesiredStatusFromEvent(event));
-      break;
-    default:
-      status = 501;
+  try {
+    switch (event.httpMethod) {
+      case "GET":
+        status = 200;
+        response = {
+          sites: getMaintenanceFile().sites
+        }
+        break;
+      case "POST":
+        const maintenanceRequest = parseBody(event.body);
+
+        // if any site is in maintenance update the file to .enabled
+        const enabled = Object.values(maintenanceRequest.sites).some(value => value === true);
+        toggleMaintenanceStatus(enabled);
+
+        // Update contents of file 
+        updateMaintenanceStatus(maintenanceRequest.sites);
+        status = 200;
+        response = {
+          sites: getMaintenanceFile().sites
+        }
+        break;
+      default:
+        status = 501;
+    }
+  } catch(error) {
+    if (error instanceof Error) {
+      status = 403;
+      response = {
+        error: error.message
+      }
+    } else {
+      console.error(JSON.stringify(error));
+      status = 500;
+      response = {
+        error: "An Unkown error ocurred."
+      }
+    }
   }
 
   return {
-    body: body,
+    body: JSON.stringify(response),
     statusCode: status,
+    headers: {
+      'content-type': 'application/json'
+    }
   };
-};
-const extractDesiredStatusFromEvent = (
-  event: APIGatewayProxyEvent
-): "enabled" | "disabled" | undefined => {
-  if (event.resource.includes("enable")) return "enabled";
-  if (event.resource.includes("disable")) return "disabled";
-  return undefined;
-};
-
-const changeMaintenanceStatus = (
-  desiredStatus?: "enabled" | "disabled"
-): string => {
-  // If no status is provided then toggle
-  if (desiredStatus === undefined) {
-    toggleMaintenanceStatus();
-    return getCurrentStatus();
-  }
-
-  const currentStatus = getCurrentStatus();
-  if (currentStatus === desiredStatus) return currentStatus;
-
-  toggleMaintenanceStatus();
-  return getCurrentStatus();
 };

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/maintenance.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/maintenance.ts
@@ -50,13 +50,14 @@ export const handler = async (
 
   try {
     switch (event.httpMethod) {
-      case "GET":
+      case "GET": {
         status = 200;
         response = {
           sites: getMaintenanceFile().sites,
         };
         break;
-      case "POST":
+      }
+      case "POST": {
         const maintenanceRequest = parseBody(event.body);
 
         // if any site is in maintenance update the file to .enabled
@@ -72,6 +73,7 @@ export const handler = async (
           sites: getMaintenanceFile().sites,
         };
         break;
+      }
       default:
         status = 501;
     }

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.test.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.test.ts
@@ -1,96 +1,103 @@
 // handler.test.ts
-import { cwd } from 'process';
-import { handler } from './whitelist';
-import { APIGatewayProxyEvent } from 'aws-lambda';
-import { setWhitelist } from './lib/file';
-import { existsSync, rmSync } from 'fs';
+import { cwd } from "process";
+import { handler } from "./whitelist";
+import { APIGatewayProxyEvent } from "aws-lambda";
+import { setWhitelist } from "./lib/file";
+import { existsSync, rmSync } from "fs";
 
-const createMockEvent = (method: string, body?: string): APIGatewayProxyEvent => ({
+const createMockEvent = (
+  method: string,
+  body?: string
+): APIGatewayProxyEvent => ({
   body: body || null,
   headers: {},
   multiValueHeaders: {},
   httpMethod: method,
   isBase64Encoded: false,
-  path: '/',
+  path: "/",
   pathParameters: null,
   queryStringParameters: null,
   multiValueQueryStringParameters: null,
   stageVariables: null,
   requestContext: {} as any,
-  resource: '/',
+  resource: "/",
 });
 const mockAllowlist = [
-    // IPv4 Addresses
-    '127.0.0.1',         // Loopback
-    '192.168.0.1',       // Private network
-    '10.0.0.1',          // Private network
-    '172.16.0.1',        // Private network (Class B range)
-    '8.8.8.8',           // Google DNS
-    '0.0.0.0',           // Non-routable meta-address
+  // IPv4 Addresses
+  "127.0.0.1", // Loopback
+  "192.168.0.1", // Private network
+  "10.0.0.1", // Private network
+  "172.16.0.1", // Private network (Class B range)
+  "8.8.8.8", // Google DNS
+  "0.0.0.0", // Non-routable meta-address
 
-    // IPv6 Addresses
-    '::1',               // Loopback
-    '2001:0db8::1',      // Documentation/test address
-    'fe80::1',           // Link-local address
-    'fd00::1',           // Unique local address
-    '::',                // Unspecified address
-    '2001:4860:4860::8888', // Google DNS IPv6
-]
-describe('Lambda handler', () => {
-    beforeAll(() => {
-        setWhitelist(mockAllowlist)
+  // IPv6 Addresses
+  "::1", // Loopback
+  "2001:0db8::1", // Documentation/test address
+  "fe80::1", // Link-local address
+  "fd00::1", // Unique local address
+  "::", // Unspecified address
+  "2001:4860:4860::8888", // Google DNS IPv6
+];
+describe("Lambda handler", () => {
+  beforeAll(() => {
+    setWhitelist(mockAllowlist);
+  });
+
+  it("should handle GET method", async () => {
+    const event = createMockEvent("GET");
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ whitelist: mockAllowlist });
+  });
+
+  it("should handle PATCH method with body", async () => {
+    const newIp = "1.1.1.1";
+    const body = JSON.stringify({ whitelist: [newIp] });
+    const event = createMockEvent("PATCH", body);
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({
+      whitelist: mockAllowlist.concat([newIp]),
     });
+  });
 
-    it('should handle GET method', async () => {
-        const event = createMockEvent('GET');
-        const result = await handler(event);
+  it("should handle PUT method with body", async () => {
+    const body = JSON.stringify({ whitelist: ["127.0.0.1"] });
+    const event = createMockEvent("PUT", body);
+    const result = await handler(event);
 
-        expect(result.statusCode).toBe(200);
-        expect(JSON.parse(result.body)).toEqual({ whitelist: mockAllowlist });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ whitelist: ["127.0.0.1"] });
+  });
+
+  it("should return 501 for unsupported methods", async () => {
+    const event = createMockEvent("DELETE");
+    const result = await handler(event);
+    expect(result.statusCode).toBe(501);
+  });
+
+  it("should return 403 for invalid ips", async () => {
+    const newIp = "192.168.1.999";
+    const body = JSON.stringify({ whitelist: [newIp] });
+    const event = createMockEvent("PATCH", body);
+    const result = await handler(event);
+
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body)).toEqual({
+      error: "List of IP addresses is not valid",
     });
+  });
 
-    it('should handle PATCH method with body', async () => {
-        const newIp = '1.1.1.1'
-        const body = JSON.stringify({ whitelist: [newIp] });
-        const event = createMockEvent('PATCH', body);
-        const result = await handler(event);
+  afterAll(() => {
+    if (existsSync(`${cwd()}/maintenance.enabled`)) {
+      rmSync(`${cwd()}/maintenance.enabled`);
+    }
 
-        expect(result.statusCode).toBe(200);
-        expect(JSON.parse(result.body)).toEqual({ whitelist: mockAllowlist.concat([newIp]) });
-    });
-
-    it('should handle PUT method with body', async () => {
-        const body = JSON.stringify({ whitelist: ['127.0.0.1'] });
-        const event = createMockEvent('PUT', body);
-        const result = await handler(event);
-
-        expect(result.statusCode).toBe(200);
-        expect(JSON.parse(result.body)).toEqual({ whitelist: ['127.0.0.1'] });
-    });
-
-    it('should return 501 for unsupported methods', async () => {
-        const event = createMockEvent('DELETE');
-        const result = await handler(event);
-        expect(result.statusCode).toBe(501);
-    });
-
-    it('should return 403 for invalid ips', async () => {
-        const newIp = '192.168.1.999'
-        const body = JSON.stringify({ whitelist: [newIp] });
-        const event = createMockEvent('PATCH', body);
-        const result = await handler(event);
-
-        expect(result.statusCode).toBe(403);
-        expect(JSON.parse(result.body)).toEqual({ error: "List of IP addresses is not valid" });
-    });
-
-    afterAll(() => {
-        if (existsSync(`${cwd()}/maintenance.enabled`)){
-            rmSync(`${cwd()}/maintenance.enabled`);
-        }
-
-        if (existsSync(`${cwd()}/maintenance.disabled`)){
-            rmSync(`${cwd()}/maintenance.disabled`);
-        } 
-    });
+    if (existsSync(`${cwd()}/maintenance.disabled`)) {
+      rmSync(`${cwd()}/maintenance.disabled`);
+    }
+  });
 });

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.test.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.test.ts
@@ -1,0 +1,96 @@
+// handler.test.ts
+import { cwd } from 'process';
+import { handler } from './whitelist';
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { setWhitelist } from './lib/file';
+import { existsSync, rmSync } from 'fs';
+
+const createMockEvent = (method: string, body?: string): APIGatewayProxyEvent => ({
+  body: body || null,
+  headers: {},
+  multiValueHeaders: {},
+  httpMethod: method,
+  isBase64Encoded: false,
+  path: '/',
+  pathParameters: null,
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  stageVariables: null,
+  requestContext: {} as any,
+  resource: '/',
+});
+const mockAllowlist = [
+    // IPv4 Addresses
+    '127.0.0.1',         // Loopback
+    '192.168.0.1',       // Private network
+    '10.0.0.1',          // Private network
+    '172.16.0.1',        // Private network (Class B range)
+    '8.8.8.8',           // Google DNS
+    '0.0.0.0',           // Non-routable meta-address
+
+    // IPv6 Addresses
+    '::1',               // Loopback
+    '2001:0db8::1',      // Documentation/test address
+    'fe80::1',           // Link-local address
+    'fd00::1',           // Unique local address
+    '::',                // Unspecified address
+    '2001:4860:4860::8888', // Google DNS IPv6
+]
+describe('Lambda handler', () => {
+    beforeAll(() => {
+        setWhitelist(mockAllowlist)
+    });
+
+    it('should handle GET method', async () => {
+        const event = createMockEvent('GET');
+        const result = await handler(event);
+
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body)).toEqual({ whitelist: mockAllowlist });
+    });
+
+    it('should handle PATCH method with body', async () => {
+        const newIp = '1.1.1.1'
+        const body = JSON.stringify({ whitelist: [newIp] });
+        const event = createMockEvent('PATCH', body);
+        const result = await handler(event);
+
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body)).toEqual({ whitelist: mockAllowlist.concat([newIp]) });
+    });
+
+    it('should handle PUT method with body', async () => {
+        const body = JSON.stringify({ whitelist: ['127.0.0.1'] });
+        const event = createMockEvent('PUT', body);
+        const result = await handler(event);
+
+        expect(result.statusCode).toBe(200);
+        expect(JSON.parse(result.body)).toEqual({ whitelist: ['127.0.0.1'] });
+    });
+
+    it('should return 403 for unsupported methods', async () => {
+        const event = createMockEvent('DELETE');
+        const result = await handler(event);
+        expect(result.statusCode).toBe(403);
+    });
+
+    it('should return 403 for invalid ips', async () => {
+        const newIp = '192.168.1.999'
+        const body = JSON.stringify({ whitelist: [newIp] });
+        const event = createMockEvent('PATCH', body);
+        const result = await handler(event);
+
+        expect(result.statusCode).toBe(403);
+        expect(JSON.parse(result.body)).toEqual({ error: "List of IP addresses is not valid" });
+    });
+
+    afterAll(() => {
+        if (existsSync(`${cwd()}/maintenance.enabled`)){
+            rmSync(`${cwd()}/maintenance.enabled`);
+        }
+
+        if (existsSync(`${cwd()}/maintenance.disabled`)){
+            rmSync(`${cwd()}/maintenance.disabled`);
+        } 
+    });
+});

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.test.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.test.ts
@@ -19,6 +19,7 @@ const createMockEvent = (
   queryStringParameters: null,
   multiValueQueryStringParameters: null,
   stageVariables: null,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   requestContext: {} as any,
   resource: "/",
 });

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.test.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.test.ts
@@ -68,10 +68,10 @@ describe('Lambda handler', () => {
         expect(JSON.parse(result.body)).toEqual({ whitelist: ['127.0.0.1'] });
     });
 
-    it('should return 403 for unsupported methods', async () => {
+    it('should return 501 for unsupported methods', async () => {
         const event = createMockEvent('DELETE');
         const result = await handler(event);
-        expect(result.statusCode).toBe(403);
+        expect(result.statusCode).toBe(501);
     });
 
     it('should return 403 for invalid ips', async () => {

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.ts
@@ -40,7 +40,7 @@ export const handler = async (
 
   let status = 501;
   let response: WhitelistErrorResponse|WhitelistResponse = {
-    error: "Method not implemented"
+    error: `Method not implemented - Received ${event.httpMethod}, with body ${event.body}.`
   };
 
   try {
@@ -68,7 +68,7 @@ export const handler = async (
         }
         break;
       default:
-        throw new Error(`Received ${event.httpMethod}, with body ${event.body}.`)
+        break;
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.ts
@@ -1,9 +1,5 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import {
-  getMaintenanceFile,
-  setWhitelist,
-  updateWhitelist,
-} from "./lib/file";
+import { getMaintenanceFile, setWhitelist, updateWhitelist } from "./lib/file";
 
 const MAINTENANCE_FILE_PATH = process.env.MAINTENANCE_FILE_PATH;
 
@@ -19,53 +15,59 @@ interface WhitelistErrorResponse {
   error: string;
 }
 
-const parseBody = function (body: string|null): WhitelistRequest {
+const parseBody = function (body: string | null): WhitelistRequest {
   if (!body) {
-    throw new Error('Update requests must contain a JSON body.');
+    throw new Error("Update requests must contain a JSON body.");
   }
 
-  let whitelistRequest = JSON.parse(body);
-  
-  if (!('whitelist' in whitelistRequest) || !Array.isArray(whitelistRequest.whitelist)) {
-      throw new Error('Update requests must contain an array of whitelisted IP addresses.');
+  const whitelistRequest = JSON.parse(body);
+
+  if (
+    !("whitelist" in whitelistRequest) ||
+    !Array.isArray(whitelistRequest.whitelist)
+  ) {
+    throw new Error(
+      "Update requests must contain an array of whitelisted IP addresses."
+    );
   }
 
   return whitelistRequest;
-}
+};
 
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
-  if (!MAINTENANCE_FILE_PATH) throw new Error("Maintenance File path is missing.");
+  if (!MAINTENANCE_FILE_PATH)
+    throw new Error("Maintenance File path is missing.");
 
   let status = 501;
-  let response: WhitelistErrorResponse|WhitelistResponse = {
-    error: `Method not implemented - Received ${event.httpMethod}, with body ${event.body}.`
+  let response: WhitelistErrorResponse | WhitelistResponse = {
+    error: `Method not implemented - Received ${event.httpMethod}, with body ${event.body}.`,
   };
 
   try {
     switch (event.httpMethod) {
       case "GET":
-        status = 200
+        status = 200;
         response = {
-          whitelist: getMaintenanceFile().whitelist
-        }
+          whitelist: getMaintenanceFile().whitelist,
+        };
         break;
       case "PUT":
-        let replaceBody = parseBody(event.body);
+        const replaceBody = parseBody(event.body);
         setWhitelist(replaceBody.whitelist);
-        status = 200
+        status = 200;
         response = {
-          whitelist: getMaintenanceFile().whitelist
-        }
+          whitelist: getMaintenanceFile().whitelist,
+        };
         break;
       case "PATCH":
-        let updateBody = parseBody(event.body);
+        const updateBody = parseBody(event.body);
         updateWhitelist(updateBody.whitelist);
-        status = 200
+        status = 200;
         response = {
-          whitelist: getMaintenanceFile().whitelist
-        }
+          whitelist: getMaintenanceFile().whitelist,
+        };
         break;
       default:
         break;
@@ -74,12 +76,12 @@ export const handler = async (
     if (error instanceof Error) {
       status = 403;
       response = {
-        error: error.message
-      }
+        error: error.message,
+      };
     } else {
       response = {
-        error: 'An unknown error ocurred.'
-      }
+        error: "An unknown error ocurred.",
+      };
     }
   }
 
@@ -87,7 +89,7 @@ export const handler = async (
     body: JSON.stringify(response),
     statusCode: status,
     headers: {
-      'content-type': 'application/json'
-    }
+      "content-type": "application/json",
+    },
   };
 };

--- a/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.ts
+++ b/packages/graphql-mesh-server/assets/handlers/maintenance/whitelist.ts
@@ -47,13 +47,14 @@ export const handler = async (
 
   try {
     switch (event.httpMethod) {
-      case "GET":
+      case "GET": {
         status = 200;
         response = {
           whitelist: getMaintenanceFile().whitelist,
         };
         break;
-      case "PUT":
+      }
+      case "PUT": {
         const replaceBody = parseBody(event.body);
         setWhitelist(replaceBody.whitelist);
         status = 200;
@@ -61,7 +62,8 @@ export const handler = async (
           whitelist: getMaintenanceFile().whitelist,
         };
         break;
-      case "PATCH":
+      }
+      case "PATCH": {
         const updateBody = parseBody(event.body);
         updateWhitelist(updateBody.whitelist);
         status = 200;
@@ -69,6 +71,7 @@ export const handler = async (
           whitelist: getMaintenanceFile().whitelist,
         };
         break;
+      }
       default:
         break;
     }

--- a/packages/graphql-mesh-server/jest.config.ts
+++ b/packages/graphql-mesh-server/jest.config.ts
@@ -8,4 +8,5 @@ export default {
   },
   moduleFileExtensions: ["ts", "js", "html"],
   coverageDirectory: "../../coverage/packages/graphql-mesh-server",
+  setupFiles: ['./jest.mock-env.ts'],
 };

--- a/packages/graphql-mesh-server/jest.mock-env.ts
+++ b/packages/graphql-mesh-server/jest.mock-env.ts
@@ -1,0 +1,3 @@
+import { cwd } from 'process';
+
+process.env.MAINTENANCE_FILE_PATH = cwd();

--- a/packages/graphql-mesh-server/jest.mock-env.ts
+++ b/packages/graphql-mesh-server/jest.mock-env.ts
@@ -1,3 +1,3 @@
-import { cwd } from 'process';
+import { cwd } from "process";
 
 process.env.MAINTENANCE_FILE_PATH = cwd();

--- a/packages/graphql-mesh-server/lib/maintenance.ts
+++ b/packages/graphql-mesh-server/lib/maintenance.ts
@@ -143,12 +143,6 @@ export class Maintenance extends Construct {
     const maintenanceInt = new apigateway.LambdaIntegration(maintenanceLambda);
     maintenance.addMethod("GET", maintenanceInt, methodOptions);
     maintenance.addMethod("POST", maintenanceInt, methodOptions);
-    maintenance
-      .addResource("enable")
-      .addMethod("POST", maintenanceInt, methodOptions);
-    maintenance
-      .addResource("disable")
-      .addMethod("POST", maintenanceInt, methodOptions);
 
     const whitelist = maintenance.addResource("whitelist");
     const whitelistLambda = new NodejsFunction(this, "whitelist-lambda", {


### PR DESCRIPTION
------

**Description of the proposed changes**  

This PR updates the whitelist API, maintenance mode API and maintenance file to use JSON so that the API and mesh can support having individual sites in / out of maintenance mode without affecting the others.

**Other solutions considered (if any)**  

I considered using multiple files with a "website scope code" e.g. `maintenance.au.enabled` but I think that will get a bit difficult to use as site counts grow. 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback