### PR TITLE
Make Lambda timeout configurable, with 10 sec by default

### DIFF
--- a/packages/header-change-detection/lib/header-change-detection.ts
+++ b/packages/header-change-detection/lib/header-change-detection.ts
@@ -50,6 +50,11 @@ export interface HeaderChangeDetectionProps {
    * @default ["200"]
    */
   acceptedHttpStatus?: string[];
+
+  /**
+   * For extended Lambda timeout. Default: 10 seconds
+   */
+  lambdaTimeout?: Duration;
 }
 
 const command = [
@@ -100,6 +105,7 @@ export class HeaderChangeDetection extends Construct {
       architecture: Architecture.X86_64,
       runtime: Runtime.NODEJS_20_X,
       handler: "header-check.handler",
+      timeout: props.lambdaTimeout || Duration.seconds(10),
       code: Code.fromAsset(join(__dirname, "lambda"), {
         bundling: {
           command,


### PR DESCRIPTION

**Description of the proposed changes**  

* Lamdba could time out especially when checking multiple domains. Making it configurable, with the default being 10 seconds, long enough to perform multiple checks. (AWS-default is 3 seconds)

**Screenshots (if applicable)**  

* 
![image](https://github.com/user-attachments/assets/b6e629b5-b624-4954-b4ea-791ec3c65028)


**Other solutions considered (if any)**  

* 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned [here](https://github.com/aligent/cdk-constructs/blob/main/CONTRIBUTING.md)

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback