### PR TITLE
TNT-1577: allow 4xx and 3xx to succeed

### DIFF
--- a/packages/prerender-fargate/lib/recaching/prerender-recache-api-construct.consumer.ts
+++ b/packages/prerender-fargate/lib/recaching/prerender-recache-api-construct.consumer.ts
@@ -16,6 +16,9 @@ export const handler = async (event: SQSEvent, _context: Context) => {
       headers: {
         "User-Agent": userAgent,
       },
+      validateStatus: function (status) {
+        return status < 500; // Don't throw an error on anything that isn't a server error
+      }
     });
     console.log(
       `Fetched URL: ${url}, Response Code: ${JSON.stringify(res.status)}`


### PR DESCRIPTION
**Description of the proposed changes**  

* Currently if Prerender returns a 4xx or 3xx axios will throw an error and the lambda will be marked as a failure. This places the page back onto the recache queue and this will repeat until the max retries have passed.
* Instead we should treat 4xx and 3xx as successes

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback