### PR TITLE
chore: replace reviewers with codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aligent/devops

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "aligent/aligent-devops"
     target-branch: "main"
     open-pull-requests-limit: 10
     ignore:                    # Ignore major version updates
@@ -77,8 +75,6 @@ updates:
       - "/packages/graphql-mesh-server/assets/nginx"
     schedule:
       interval: "weekly"
-    reviewers:                        # Reviewers for Docker image updates.    
-      - "aligent/aligent-devops"
     target-branch: "main"
     open-pull-requests-limit: 10
     ignore:
@@ -95,7 +91,5 @@ updates:
     directory: "/"                    # Monitors all workflows in the repository.
     schedule:
       interval: "weekly"
-    reviewers:                        # Reviewers for Docker image updates.    
-      - "aligent/aligent-devops"
     target-branch: "main"
     open-pull-requests-limit: 5


### PR DESCRIPTION
**Description of the proposed changes**  

* Reviewers in dependabot are being deprecated
* Replaces reviewers in dependabot with CODEOWNERS

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback