### PR TITLE
DO-1284: Fix changeset release workflow lockfile issue

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -39,9 +39,10 @@ jobs:
         run: |
           set +e  # Don't exit on error
           
-          # Get affected packages using Nx (more accurate than changeset detection)
-          echo "Getting affected packages from Nx..."
-          AFFECTED_PACKAGES=$(npx nx show projects --affected --base=${{ github.event.pull_request.base.sha }} --head=HEAD --json 2>/dev/null || echo "[]")
+          # Get affected packages using git diff (avoid nx lockfile issues)
+          echo "Getting affected packages from git diff..."
+          AFFECTED_PACKAGES_NAMES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...HEAD | grep '^packages/' | cut -d'/' -f2 | sort | uniq)
+          AFFECTED_PACKAGES=$(echo "$AFFECTED_PACKAGES_NAMES" | jq -R . | jq -s . 2>/dev/null || echo "[]")
           
           # Get all publishable CDK package names dynamically
           ALL_PUBLISHABLE_PACKAGES=$(find packages -maxdepth 1 -type d -not -path packages | xargs -n1 basename | sed 's/^/@aligent\/cdk-/')

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -65,6 +65,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # Update lockfile after changeset version updates
+      - name: Update lockfile
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        run: |
+          yarn install --mode update-lockfile
+          git add yarn.lock
+          git commit -m "chore: update lockfile after version bumps" || echo "No lockfile changes to commit"
+
       - name: Publish Release Info
         if: steps.changesets.outputs.published == 'true'
         run: |

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -65,14 +65,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Update lockfile after changeset version updates
-      - name: Update lockfile
-        if: steps.changesets.outputs.hasChangesets == 'true'
-        run: |
-          yarn install --mode update-lockfile
-          git add yarn.lock
-          git commit -m "chore: update lockfile after version bumps" || echo "No lockfile changes to commit"
-
       - name: Publish Release Info
         if: steps.changesets.outputs.published == 'true'
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,7 +45,7 @@ jobs:
           cache: "yarn"
 
       - name: Install
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Build all packages
         run: yarn nx run-many -t build
@@ -76,7 +76,7 @@ jobs:
           cache: "yarn"
 
       - name: Install
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Build all packages
         run: yarn nx run-many -t build

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -1,0 +1,57 @@
+name: Update Lockfile
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '.changeset/**'
+      - 'packages/**/package.json'
+      - 'package.json'
+
+jobs:
+  update-lockfile:
+    name: 📦 Update yarn.lock
+    runs-on: ubuntu-latest
+    # Only run on changeset release PRs
+    if: |
+      contains(github.head_ref, 'changeset-release/') || 
+      contains(github.event.pull_request.title, 'chore: release packages')
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "yarn"
+
+      - name: Update Lockfile
+        run: |
+          # Update lockfile to match package.json changes
+          yarn install --mode update-lockfile
+          
+          # Check if lockfile was modified
+          if git diff --quiet yarn.lock; then
+            echo "No lockfile changes needed"
+            exit 0
+          fi
+
+      - name: Commit Lockfile Changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          
+          git add yarn.lock
+          git commit -m "chore: update lockfile after version bumps"
+          git push

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-basic-auth@workspace:packages/basic-auth"
   dependencies:
-    "@aligent/cdk-esbuild": "npm:^2.0"
+    "@aligent/cdk-esbuild": "npm:^2.5.0"
     "@types/aws-lambda": "npm:^8.10.150"
     "@types/jest": "npm:^29.5.10"
     "@types/node": "npm:^20.6.3"
@@ -29,7 +29,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-cloudfront-security-headers@workspace:packages/cloudfront-security-headers"
   dependencies:
-    "@aligent/cdk-esbuild": "npm:^2.0"
+    "@aligent/cdk-esbuild": "npm:^2.5.0"
     "@types/aws-lambda": "npm:^8.10.150"
     "@types/jest": "npm:^29.5.10"
     "@types/node": "npm:^20.6.3"
@@ -74,7 +74,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aligent/cdk-esbuild@npm:^2.0, @aligent/cdk-esbuild@workspace:packages/esbuild":
+"@aligent/cdk-esbuild@npm:^2.5.0, @aligent/cdk-esbuild@workspace:packages/esbuild":
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-esbuild@workspace:packages/esbuild"
   dependencies:
@@ -105,7 +105,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-geoip-redirect@workspace:packages/geoip-redirect"
   dependencies:
-    "@aligent/cdk-esbuild": "npm:^2.0"
+    "@aligent/cdk-esbuild": "npm:^2.5.0"
     "@types/aws-lambda": "npm:^8.10.150"
     "@types/jest": "npm:^29.5.10"
     "@types/node": "npm:^20.6.3"
@@ -187,7 +187,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-prerender-proxy@workspace:packages/prerender-proxy"
   dependencies:
-    "@aligent/cdk-esbuild": "npm:^2.0"
+    "@aligent/cdk-esbuild": "npm:^2.5.0"
     "@types/aws-lambda": "npm:^8.10.150"
     "@types/jest": "npm:^29.5.10"
     "@types/node": "npm:^20.6.3"
@@ -244,7 +244,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-static-hosting@workspace:packages/static-hosting"
   dependencies:
-    "@aligent/cdk-esbuild": "npm:^2.0"
+    "@aligent/cdk-esbuild": "npm:^2.5.0"
     "@aws-sdk/client-s3": "npm:^3.832.0"
     "@types/aws-lambda": "npm:^8.10.150"
     "@types/jest": "npm:^29.5.10"


### PR DESCRIPTION
## Summary
This PR fixes lockfile issues in our CI/CD workflows by:
1. Adding frozen lockfile checks to pull requests
2. Updating the lockfile during releases when changesets modifies package versions
3. Fixing changeset package detection to avoid false positives from nx

## Problem
When changesets updates package.json files during the release process, the yarn.lock file becomes out of sync. This causes subsequent `yarn install --frozen-lockfile` commands to fail because the lockfile doesn't match the updated package.json files.

Additionally, nx was incorrectly marking all packages as "affected" whenever yarn.lock changed, causing unnecessary CI runs and changeset checks even when no actual package code changed.

This issue is documented in the changesets repository: https://github.com/changesets/changesets/issues/421

## Solution
1. **Pull Request Workflow**: Added `--frozen-lockfile` flag to `yarn install` commands to ensure lockfile integrity during PR checks
2. **Release Workflow**: Added a new workflow that:
   - Triggers on changeset release PRs
   - Updates the lockfile using `yarn install --mode update-lockfile`
   - Commits the updated lockfile to keep it in sync with version changes
3. **Changeset Detection**: Modified changeset-check workflow to use `git diff` instead of `nx affected` to detect which packages actually changed, avoiding false positives from yarn.lock changes

## Changes
- Modified `.github/workflows/pull-request.yml` to use `yarn install --frozen-lockfile`
- Added `.github/workflows/update-lockfile.yml` to handle lockfile updates on changeset PRs
- Updated `.github/workflows/changeset-check.yml` to use git diff for package detection instead of nx
- The lockfile update only runs when actual package changes are detected, not just workflow or lockfile changes

## Related
- Failed release run: https://github.com/aligent/cdk-constructs/actions/runs/16488145899
- Changesets issue: https://github.com/changesets/changesets/issues/421