### PR TITLE
TNT-1615: Fix CSP Lambda error handling when fallback is provided

### DIFF
--- a/.changeset/short-ways-tie.md
+++ b/.changeset/short-ways-tie.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-static-hosting": patch
+---
+
+Fix CSP Lambda error handling when fallback is provided

--- a/packages/static-hosting/lib/handlers/csp-lambda/origin-response.ts
+++ b/packages/static-hosting/lib/handlers/csp-lambda/origin-response.ts
@@ -55,10 +55,11 @@ export const handler = async (
     // If no fallback was provided, throw the error and 500 response
     if (!FALLBACK_CSP) throw error;
 
+    // Use fallback CSP
+    console.log("Using fallback CSP:", FALLBACK_CSP);
     response.headers["content-security-policy"] = [
       { key: "Content-Security-Policy", value: FALLBACK_CSP },
     ];
-    throw error;
   }
 
   return response;


### PR DESCRIPTION
## Summary
- Fixed error handling in CSP Lambda to properly use fallback CSP without throwing errors
- Lambda now returns successfully when fallback CSP is applied instead of returning error response

## Problem
The CSP Lambda was throwing an error even after successfully applying the fallback CSP value. This caused CloudFront to receive error responses despite the CSP headers being correctly set with the fallback value.

## Solution
Removed the `throw error` statement after setting the fallback CSP headers. The Lambda now:
1. Logs the error for debugging purposes
2. Applies the fallback CSP to response headers
3. Returns successfully without throwing

## Test plan
- [x] Deploy Lambda with fallback CSP configured
- [x] Remove/rename CSP file in S3 to trigger fallback
- [x] Verify CloudFront returns 200 with fallback CSP headers
- [x] Check Lambda logs show fallback was used

🤖 Generated with [Claude Code](https://claude.ai/code)