### PR TITLE
DO-1802: Fix changeset release workflow lockfile updates

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release
+          version: yarn changeset:version && yarn install # update the yarn lockfile after versioning
           title: "chore: release packages"
           commit: "chore: release packages"
           createGithubReleases: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-basic-auth@workspace:packages/basic-auth"
   dependencies:
-    "@aligent/cdk-esbuild": "npm:^2.5.0"
+    "@aligent/cdk-esbuild": "npm:^2.5.1"
     "@types/aws-lambda": "npm:^8.10.150"
     "@types/jest": "npm:^29.5.10"
     "@types/node": "npm:^20.6.3"
@@ -29,7 +29,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-cloudfront-security-headers@workspace:packages/cloudfront-security-headers"
   dependencies:
-    "@aligent/cdk-esbuild": "npm:^2.5.0"
+    "@aligent/cdk-esbuild": "npm:^2.5.1"
     "@types/aws-lambda": "npm:^8.10.150"
     "@types/jest": "npm:^29.5.10"
     "@types/node": "npm:^20.6.3"
@@ -74,7 +74,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@aligent/cdk-esbuild@npm:^2.5.0, @aligent/cdk-esbuild@workspace:packages/esbuild":
+"@aligent/cdk-esbuild@npm:^2.5.1, @aligent/cdk-esbuild@workspace:packages/esbuild":
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-esbuild@workspace:packages/esbuild"
   dependencies:
@@ -105,7 +105,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-geoip-redirect@workspace:packages/geoip-redirect"
   dependencies:
-    "@aligent/cdk-esbuild": "npm:^2.5.0"
+    "@aligent/cdk-esbuild": "npm:^2.5.1"
     "@types/aws-lambda": "npm:^8.10.150"
     "@types/jest": "npm:^29.5.10"
     "@types/node": "npm:^20.6.3"
@@ -187,7 +187,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-prerender-proxy@workspace:packages/prerender-proxy"
   dependencies:
-    "@aligent/cdk-esbuild": "npm:^2.5.0"
+    "@aligent/cdk-esbuild": "npm:^2.5.1"
     "@types/aws-lambda": "npm:^8.10.150"
     "@types/jest": "npm:^29.5.10"
     "@types/node": "npm:^20.6.3"
@@ -244,7 +244,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-static-hosting@workspace:packages/static-hosting"
   dependencies:
-    "@aligent/cdk-esbuild": "npm:^2.5.0"
+    "@aligent/cdk-esbuild": "npm:^2.5.1"
     "@aws-sdk/client-s3": "npm:^3.832.0"
     "@types/aws-lambda": "npm:^8.10.150"
     "@types/jest": "npm:^29.5.10"


### PR DESCRIPTION
## Summary
- Fix changeset release workflow failing due to lockfile modification restrictions
- Update lockfile after package versioning but before committing
- Ensures release PRs include updated yarn.lock with correct interdependency versions

## Problem
The release process was failing with error:
```
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

This occurred because:
1. During changeset publish, package interdependencies are updated (e.g., `@aligent/cdk-esbuild` from `^2.5.0` to `^2.5.1`)
2. These updates require lockfile changes but weren't being committed to the release PR
3. The workflow tried to install with outdated lockfile entries

## Solution
- Add `version: yarn changeset:version && yarn install` to update lockfile after versioning
- This ensures release PRs contain both version bumps AND updated lockfiles
- Maintains build reproducibility while allowing necessary lockfile updates

Fixes: https://github.com/aligent/cdk-constructs/actions/runs/16822839707/job/47653034014