### PR TITLE
DO-1926: Updated Prerender ALB to support only TLS 1.2 and 1.3

### DIFF
--- a/.changeset/gentle-lemons-care.md
+++ b/.changeset/gentle-lemons-care.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-prerender-fargate": minor
+---
+
+Updated Prerender Fargate ALB from implicity TLS v1 to explicit 1.2 and 1.3

--- a/packages/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/prerender-fargate/lib/prerender-fargate.ts
@@ -13,6 +13,7 @@ import { PrerenderRecacheApi } from "./recaching/prerender-recache-api-construct
 import { PrerenderFargateOptions } from "./prerender-fargate-options";
 import { PerformanceMetrics } from "./monitoring";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { SslPolicy } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 
 /**
  * `PrerenderFargate` construct sets up an AWS Fargate service to run a
@@ -214,6 +215,7 @@ export class PrerenderFargate extends Construct {
               ? ec2.SubnetType.PRIVATE_WITH_EGRESS
               : ec2.SubnetType.PUBLIC,
           },
+          sslPolicy: SslPolicy.TLS13_RES,
         }
       );
 


### PR DESCRIPTION
**Description of the proposed changes**  

* Updated Prerender Fargate ALB from implicitly using TLS v1 to explicitly using TLS v1.2 and v1.3

**Screenshots (if applicable)**  

* N/A

**Other solutions considered (if any)**  

* N/A

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback