### PR TITLE
Fix changeset release workflow command syntax

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release
-          version: yarn changeset:version && yarn install # update the yarn lockfile after versioning
+          version: yarn changeset:version-and-install
           title: "chore: release packages"
           commit: "chore: release packages"
           createGithubReleases: true

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "changeset": "changeset",
     "changeset:version": "changeset version",
+    "changeset:version-and-install": "changeset version && yarn install",
     "changeset:publish": "changeset publish",
     "release": "changeset publish",
     "changeset:status": "changeset status",


### PR DESCRIPTION
**Description of the proposed changes**  

* The `version` keyword doesn't support bash commands. I've moved the yarn install to a node script

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback