### PR TITLE
Chore/do 1802 undefined additional behavior path

### DIFF
--- a/.changeset/tame-donkeys-unite.md
+++ b/.changeset/tame-donkeys-unite.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-static-hosting": patch
+---
+
+Fixed undefined error for Static Hosting additionalBehavior paths

--- a/packages/static-hosting/lib/static-hosting.ts
+++ b/packages/static-hosting/lib/static-hosting.ts
@@ -679,8 +679,12 @@ export class StaticHosting extends Construct {
     if (props.responseHeadersPolicies?.additionalBehaviorResponsePolicy) {
       for (const path in props.responseHeadersPolicies
         .additionalBehaviorResponsePolicy) {
-        additionalBehaviors[path].responseHeadersPolicy =
-          props.responseHeadersPolicies.additionalBehaviorResponsePolicy[path];
+        if (additionalBehaviors[path]) {
+          additionalBehaviors[path].responseHeadersPolicy =
+            props.responseHeadersPolicies.additionalBehaviorResponsePolicy[
+              path
+            ];
+        }
       }
     }
 


### PR DESCRIPTION
**Description of the proposed changes**  

* Add simple check to ensure that a path provided by a stack, exists as an additionalBehavior to prevent possibly undefined error.

**Screenshots (if applicable)**  

* I made the change to my local `node_modules` copy of the Static Hosting Construct, and it looks to have worked:
<img width="363" height="65" alt="image" src="https://github.com/user-attachments/assets/ff6e9865-b96d-4329-b218-4b73132ec22e" />


**Other solutions considered (if any)**  

* N/A

**Notes to reviewers**  
When passing an additionalBehaviorResponsePolicy via responseHeadersPolicies to the construct and performing a cdk diff, the construct returns:

```
additionalBehaviors[path].responseHeadersPolicy =
                                                       ^
TypeError: Cannot set properties of undefined (setting 'responseHeadersPolicy')

```

I believe this occurs when trying to add a policy to a behaviour that is created in the construct, but the construct doesn't handle the case when the path isn't created.

Below is a code snippet from a stack attempting to define a policy for an additional behavior:

```
responseHeadersPolicies["additionalBehaviorResponsePolicy"]["/au/*.js"] =
  new ResponseHeadersPolicy(this, `HstsPolicy-/au/*.js)}`, {
    securityHeadersBehavior: securityHeaderPolicy
}); 
```


🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback