### PR TITLE
DO-1765: Fix CI lockfile immutability check

### DIFF
--- a/.changeset/fix-types-node-lockfile.md
+++ b/.changeset/fix-types-node-lockfile.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-nodejs-function-from-entry": patch
+---
+
+Align @types/node version with other packages to fix yarn lockfile immutability check in CI

--- a/packages/constructs/nodejs-function-from-entry/package.json
+++ b/packages/constructs/nodejs-function-from-entry/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.10",
-    "@types/node": "^20.19.37",
+    "@types/node": "^20.19.39",
     "aws-cdk": "^2.1019.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,7 +218,7 @@ __metadata:
   resolution: "@aligent/cdk-nodejs-function-from-entry@workspace:packages/constructs/nodejs-function-from-entry"
   dependencies:
     "@types/jest": "npm:^29.5.10"
-    "@types/node": "npm:^20.19.37"
+    "@types/node": "npm:^20.19.39"
     aws-cdk: "npm:^2.1019.1"
     jest: "npm:^29.7.0"
     ts-jest: "npm:^29.1.1"


### PR DESCRIPTION
**Description of the proposed changes**

PR #1643 (MI-314) added the `nodejs-function-from-entry` package with `@types/node: ^20.19.37`, while all other packages use `^20.19.39`. This caused `yarn install --immutable` to fail in CI because the lockfile needed to add the `^20.19.37` specifier.

This aligns the version to `^20.19.39` and updates the lockfile accordingly.

**Notes to reviewers**

- Single-line change in `package.json` plus the resulting lockfile update
- The [failed Release run](https://github.com/aligent/cdk-constructs/actions/runs/24381864986) should pass after this merge

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback