### PR TITLE
Add workflow_dispatch trigger to pull request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,8 @@
 name: Pull Request
 
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   install:
@@ -40,7 +42,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
     env:
-      PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      PR_BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
 
   lint:
     name: 🔍 Lint affected packages
@@ -76,7 +78,7 @@ jobs:
         run: yarn nx affected:lint --base=origin/${{ env.PR_BASE_REF }} --parallel --max-parallel=3 
 
     env:
-      PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      PR_BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
 
   build:
     name: 🏭 Build affected packages
@@ -112,7 +114,7 @@ jobs:
         run: yarn nx affected:build --base=origin/${{ env.PR_BASE_REF }} --parallel --max-parallel=3
 
     env:
-      PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      PR_BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
 
   test:
     name: 🧪 Run tests
@@ -151,4 +153,4 @@ jobs:
         run: yarn nx affected:test --base=origin/${{ env.PR_BASE_REF }} --parallel --max-parallel=3
 
     env:
-      PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      PR_BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint-config-prettier": "^9.1.0"
   },
   "resolutions": {
-    "esbuild": "0.25.0",
     "form-data": "4.0.4",
     "brace-expansion": "1.1.12",
     "@smithy/config-resolver": "4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7305,7 +7305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:0.28.0":
+"esbuild@npm:^0.28.0":
   version: 0.28.0
   resolution: "esbuild@npm:0.28.0"
   dependencies:


### PR DESCRIPTION
**Description of the proposed changes**

Adds a `workflow_dispatch` trigger to the Pull Request workflow, allowing it to be run manually from the GitHub Actions UI.

Also adds a fallback to `main` for the `PR_BASE_REF` env var (`|| 'main'`) so the `nx affected` commands have a valid base ref when triggered outside of a pull request context.

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback