### PR TITLE
MI-314: Improve type inference and path validation for Lambda and SFN constructs

### DIFF
--- a/.changeset/tame-suns-dream.md
+++ b/.changeset/tame-suns-dream.md
@@ -1,0 +1,23 @@
+---
+"@aligent/cdk-nodejs-function-from-entry": minor
+"@aligent/cdk-step-function-from-file": minor
+"@aligent/cdk-aspects": patch
+---
+
+### `@aligent/cdk-nodejs-function-from-entry` (minor)
+
+- **Changed base class from `Function` to `NodejsFunction`** — the construct now extends `NodejsFunction` (and accepts `NodejsFunctionProps`) instead of the generic `Function`, enabling Node.js-specific bundling options. The parent `entry` prop is omitted to avoid conflicts with the custom typed `entry`.
+- **Added `NoInfer` to the `entry` generic parameter** — prevents TypeScript from incorrectly inferring `TPrefix` from the `entry` value; the prefix is now inferred solely from `sourcePrefix`.
+- **Made `runtime` optional** — consumers no longer need to explicitly pass a runtime.
+- **Improved path traversal validation** — replaced the simple relative-path check with a `findServiceRoot` helper that walks up to a configurable `rootParentDir` ancestor, giving clearer error messages on invalid paths.
+- **Added `rootParentDir` prop** (default: `'services'`) to control the allowed root for asset resolution.
+
+### `@aligent/cdk-step-function-from-file` (minor)
+
+- **Added `NoInfer` to the `filepath` generic parameter** — prevents unintended type inference from the `filepath` value.
+- **Improved path traversal validation** — uses the same `findServiceRoot` approach as the Lambda construct for consistent, configurable path safety checks.
+- **Added `rootParentDir` prop** (default: `'services'`) to control the allowed root for asset resolution.
+
+### `@aligent/cdk-aspects` (patch)
+
+- **Updated `NodeJsFunctionDefaultsAspect` JSDoc** — clarified that the configured runtime is always applied to ensure consistency, while other defaults (tracing, memory, timeout, source maps) are only applied when not already set.

--- a/packages/cdk-aspects/lib/defaults/nodejs-function.ts
+++ b/packages/cdk-aspects/lib/defaults/nodejs-function.ts
@@ -52,10 +52,12 @@ export class NodeJsFunctionDefaultsAspect implements IAspect {
   }
 
   /**
-   * Visits a construct and applies runtime and tracing settings if it's a NodejsFunction
+   * Visits a construct and applies defaults if it's a Node.js Lambda function.
    *
-   * Applies configuration-specific runtime, tracing, and environment settings to Node.js
-   * Lambda functions that don't already have these properties explicitly set.
+   * The configured runtime is **always** applied to
+   * ensure consistency across the stack — even if the function already
+   * specifies a Node.js runtime. Tracing, memory, timeout, and source map
+   * settings are only applied when not already explicitly set.
    *
    * @param node - The construct to potentially modify
    */

--- a/packages/constructs/nodejs-function-from-entry/lib/nodejs-function-from-entry.test.ts
+++ b/packages/constructs/nodejs-function-from-entry/lib/nodejs-function-from-entry.test.ts
@@ -1,0 +1,106 @@
+import { Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { Code, Runtime } from "aws-cdk-lib/aws-lambda";
+import path from "path";
+
+import { NodejsFunctionFromEntry } from "./nodejs-function-from-entry";
+
+// Mock Code.fromAsset to avoid needing real dist directories on disk.
+jest.mock("aws-cdk-lib/aws-lambda", () => {
+  const actual = jest.requireActual("aws-cdk-lib/aws-lambda");
+  return {
+    ...actual,
+    Code: {
+      ...actual.Code,
+      fromAsset: jest.fn((assetPath: string) =>
+        actual.Code.fromInline(`// asset: ${assetPath}`)
+      ),
+    },
+  };
+});
+
+// The test __dirname lives under packages/constructs/nodejs-function-from-entry/lib,
+// so "constructs" is the parent-of-parent dir name we can use as rootParentDir.
+const ROOT_PARENT_DIR = "constructs";
+
+describe("NodejsFunctionFromEntry", () => {
+  let stack: Stack;
+
+  beforeEach(() => {
+    stack = new Stack();
+    (Code.fromAsset as jest.Mock).mockClear();
+  });
+
+  test("creates a Lambda function with default prefixes", () => {
+    new NodejsFunctionFromEntry(stack, "Handler", {
+      entry: "runtime/handlers/fetch-data.ts",
+      baseDir: __dirname,
+      runtime: Runtime.NODEJS_22_X,
+      rootParentDir: ROOT_PARENT_DIR,
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "index.handler",
+    });
+
+    // Verify Code.fromAsset was called with the resolved dist path
+    expect(Code.fromAsset).toHaveBeenCalledWith(
+      path.resolve(__dirname, "../dist/fetch-data")
+    );
+  });
+
+  test("creates a Lambda function with custom sourcePrefix and distPrefix", () => {
+    new NodejsFunctionFromEntry(stack, "Custom", {
+      entry: "src/handlers/process.ts",
+      baseDir: __dirname,
+      sourcePrefix: "src/handlers/",
+      distPrefix: "../build/",
+      runtime: Runtime.NODEJS_22_X,
+      rootParentDir: ROOT_PARENT_DIR,
+    });
+
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "index.handler",
+    });
+
+    expect(Code.fromAsset).toHaveBeenCalledWith(
+      path.resolve(__dirname, "../build/process")
+    );
+  });
+
+  test("throws when resolved path is outside the allowed root", () => {
+    expect(() => {
+      new NodejsFunctionFromEntry(stack, "BadPath", {
+        entry: "runtime/handlers/../../../../../../etc/passwd.ts",
+        baseDir: __dirname,
+        runtime: Runtime.NODEJS_22_X,
+        rootParentDir: ROOT_PARENT_DIR,
+      });
+    }).toThrow(/Path traversal detected/);
+  });
+
+  test("throws when no matching rootParentDir ancestor exists", () => {
+    expect(() => {
+      new NodejsFunctionFromEntry(stack, "NoRoot", {
+        entry: "runtime/handlers/fetch-data.ts",
+        baseDir: __dirname,
+        runtime: Runtime.NODEJS_22_X,
+        rootParentDir: "nonexistent-parent",
+      });
+    }).toThrow(/Could not find a 'nonexistent-parent\/<name>' ancestor/);
+  });
+
+  test("uses custom rootParentDir for path validation", () => {
+    // "packages" is also a valid ancestor for the test directory
+    expect(() => {
+      new NodejsFunctionFromEntry(stack, "PackagesRoot", {
+        entry: "runtime/handlers/fetch-data.ts",
+        baseDir: __dirname,
+        runtime: Runtime.NODEJS_22_X,
+        rootParentDir: "packages",
+      });
+    }).not.toThrow();
+  });
+});

--- a/packages/constructs/nodejs-function-from-entry/lib/nodejs-function-from-entry.ts
+++ b/packages/constructs/nodejs-function-from-entry/lib/nodejs-function-from-entry.ts
@@ -8,7 +8,7 @@ import path from "path";
 
 export interface NodejsFunctionFromEntryProps<
   TPrefix extends string = "runtime/handlers/",
-> extends Omit<NodejsFunctionProps, "code" | "handler"> {
+> extends Omit<NodejsFunctionProps, "code" | "handler" | "entry"> {
   /**
    * Base directory to resolve paths from.
    * Typically set to `import.meta.dirname` of the calling module.
@@ -38,7 +38,7 @@ export interface NodejsFunctionFromEntryProps<
 }
 
 /**
- * A self-contained construct that wraps `Function` and resolves a
+ * A self-contained construct that wraps `NodejsFunction` and resolves a
  * source `entry` path to a pre-bundled code asset.
  *
  * Given an entry like `runtime/handlers/fetch-data.ts`, the source prefix
@@ -96,7 +96,7 @@ export class NodejsFunctionFromEntry<
 
   /**
    * Walks up from the given directory until it finds a path
-   * whose parent directory is named `services` (e.g. `services/companies`).
+   * whose parent directory is named the given rootParentDir (e.g. `services/companies`).
    */
   private static findServiceRoot(dir: string, rootParentDir: string): string {
     let current = path.resolve(dir);

--- a/packages/constructs/nodejs-function-from-entry/lib/nodejs-function-from-entry.ts
+++ b/packages/constructs/nodejs-function-from-entry/lib/nodejs-function-from-entry.ts
@@ -1,41 +1,40 @@
+import { Code } from "aws-cdk-lib/aws-lambda";
 import {
-  Code,
-  Function,
-  type FunctionProps,
-  Runtime,
-} from "aws-cdk-lib/aws-lambda";
+  NodejsFunction,
+  NodejsFunctionProps,
+} from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
 import path from "path";
 
 export interface NodejsFunctionFromEntryProps<
   TPrefix extends string = "runtime/handlers/",
-> extends Omit<FunctionProps, "code" | "handler" | "runtime"> {
-  /**
-   * The runtime environment for the Lambda function.
-   * Optional when using `NodeJsFunctionDefaultsAspect` to set the runtime via an aspect.
-   * @default Runtime.NODEJS_LATEST
-   */
-  readonly runtime?: FunctionProps["runtime"];
-  /**
-   * Path to the TypeScript handler source file
-   * (e.g. `'runtime/handlers/fetch-data.ts'`).
-   */
-  readonly entry: `${NoInfer<TPrefix>}${string}`;
+> extends Omit<NodejsFunctionProps, "code" | "handler"> {
   /**
    * Base directory to resolve paths from.
    * Typically set to `import.meta.dirname` of the calling module.
    */
   readonly baseDir: string;
   /**
-   * Source path prefix to strip when mapping to the dist output.
+   * Path to the TypeScript handler source file
+   * (e.g. `'runtime/handlers/fetch-data.ts'`).
+   */
+  readonly entry: `${NoInfer<TPrefix>}${string}`;
+  /**
+   * Source path prefix (relative to baseDir) to strip when mapping to the dist output.
    * @default `'runtime/handlers/'`
    */
-  readonly sourcePrefix?: string;
+  readonly sourcePrefix?: TPrefix;
   /**
-   * Output dist path prefix to substitute in.
+   * Output dist path prefix to substitute in (relative to baseDir)
    * @default `'../dist/'`
    */
   readonly distPrefix?: string;
+  /**
+   * Parent directory name used to determine the allowed root for path traversal.
+   * The allowed root is the first ancestor whose parent matches this name.
+   * @default `'services'`
+   */
+  readonly rootParentDir?: string;
 }
 
 /**
@@ -57,8 +56,8 @@ export interface NodejsFunctionFromEntryProps<
  *   baseDir: import.meta.dirname,
  * });
  *
- * // With custom prefix and dist path
- * new NodejsFunctionFromEntry<'src/handlers/'>(stack, 'FetchData', {
+ * // With custom prefix and dist path (TPrefix inferred from sourcePrefix)
+ * new NodejsFunctionFromEntry(stack, 'FetchData', {
  *   entry: 'src/handlers/fetch-data.ts',
  *   baseDir: import.meta.dirname,
  *   sourcePrefix: 'src/handlers/',
@@ -68,7 +67,7 @@ export interface NodejsFunctionFromEntryProps<
  */
 export class NodejsFunctionFromEntry<
   TPrefix extends string = "runtime/handlers/",
-> extends Function {
+> extends NodejsFunction {
   constructor(
     scope: Construct,
     id: string,
@@ -79,6 +78,7 @@ export class NodejsFunctionFromEntry<
       baseDir,
       sourcePrefix = "runtime/handlers/",
       distPrefix = "../dist/",
+      rootParentDir = "services",
       ...rest
     } = props;
 
@@ -87,15 +87,31 @@ export class NodejsFunctionFromEntry<
         entry,
         baseDir,
         sourcePrefix,
-        distPrefix
+        distPrefix,
+        rootParentDir
       );
 
-    super(scope, id, {
-      code,
-      handler: resolvedHandler,
-      runtime: Runtime.NODEJS_LATEST,
-      ...rest,
-    });
+    super(scope, id, { code, handler: resolvedHandler, ...rest });
+  }
+
+  /**
+   * Walks up from the given directory until it finds a path
+   * whose parent directory is named `services` (e.g. `services/companies`).
+   */
+  private static findServiceRoot(dir: string, rootParentDir: string): string {
+    let current = path.resolve(dir);
+    const root = path.parse(current).root;
+
+    while (current !== root) {
+      if (path.basename(path.dirname(current)) === rootParentDir) {
+        return current;
+      }
+      current = path.dirname(current);
+    }
+
+    throw new Error(
+      `Could not find a '${rootParentDir}/<name>' ancestor from ${dir}`
+    );
   }
 
   /**
@@ -108,7 +124,8 @@ export class NodejsFunctionFromEntry<
     entry: string,
     baseDir: string,
     sourcePrefix: string,
-    distPrefix: string
+    distPrefix: string,
+    rootParentDir: string
   ): { code: Code; handler: string } {
     const escapedPrefix = sourcePrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const bundledPath = entry.replace(
@@ -117,10 +134,15 @@ export class NodejsFunctionFromEntry<
     );
 
     const target = path.resolve(baseDir, bundledPath);
-    const relative = path.relative(baseDir, target);
+    const allowedRoot = NodejsFunctionFromEntry.findServiceRoot(
+      baseDir,
+      rootParentDir
+    );
 
-    if (relative.startsWith("..") || path.isAbsolute(relative)) {
-      throw new Error("Invalid file path");
+    if (!target.startsWith(allowedRoot + path.sep) && target !== allowedRoot) {
+      throw new Error(
+        `Path traversal detected: resolved path '${target}' is outside allowed root '${allowedRoot}'`
+      );
     }
 
     return {

--- a/packages/constructs/nodejs-function-from-entry/lib/nodejs-function-from-entry.ts
+++ b/packages/constructs/nodejs-function-from-entry/lib/nodejs-function-from-entry.ts
@@ -9,7 +9,7 @@ export interface NodejsFunctionFromEntryProps<
    * Path to the TypeScript handler source file
    * (e.g. `'runtime/handlers/fetch-data.ts'`).
    */
-  readonly entry: `${TPrefix}${string}`;
+  readonly entry: `${NoInfer<TPrefix>}${string}`;
   /**
    * Base directory to resolve paths from.
    * Typically set to `import.meta.dirname` of the calling module.

--- a/packages/constructs/nodejs-function-from-entry/lib/nodejs-function-from-entry.ts
+++ b/packages/constructs/nodejs-function-from-entry/lib/nodejs-function-from-entry.ts
@@ -1,10 +1,21 @@
-import { Code, Function, type FunctionProps } from "aws-cdk-lib/aws-lambda";
+import {
+  Code,
+  Function,
+  type FunctionProps,
+  Runtime,
+} from "aws-cdk-lib/aws-lambda";
 import { Construct } from "constructs";
 import path from "path";
 
 export interface NodejsFunctionFromEntryProps<
   TPrefix extends string = "runtime/handlers/",
-> extends Omit<FunctionProps, "code" | "handler"> {
+> extends Omit<FunctionProps, "code" | "handler" | "runtime"> {
+  /**
+   * The runtime environment for the Lambda function.
+   * Optional when using `NodeJsFunctionDefaultsAspect` to set the runtime via an aspect.
+   * @default Runtime.NODEJS_LATEST
+   */
+  readonly runtime?: FunctionProps["runtime"];
   /**
    * Path to the TypeScript handler source file
    * (e.g. `'runtime/handlers/fetch-data.ts'`).
@@ -79,7 +90,12 @@ export class NodejsFunctionFromEntry<
         distPrefix
       );
 
-    super(scope, id, { code, handler: resolvedHandler, ...rest });
+    super(scope, id, {
+      code,
+      handler: resolvedHandler,
+      runtime: Runtime.NODEJS_LATEST,
+      ...rest,
+    });
   }
 
   /**

--- a/packages/constructs/step-function-from-file/lib/step-function-from-file-construct.test.ts
+++ b/packages/constructs/step-function-from-file/lib/step-function-from-file-construct.test.ts
@@ -8,6 +8,10 @@ import { StepFunctionFromFile } from "./step-function-from-file-construct";
 const snapshotMessage =
   "Rerun tests with the -u flag to update snapshots if changes are expected";
 
+// The test __dirname lives under packages/constructs/step-function-from-file/lib,
+// so "constructs" is the parent-of-parent dir name we can use as rootParentDir.
+const ROOT_PARENT_DIR = "constructs";
+
 describe("StepFunctionFromFile", () => {
   let stack: Stack;
 
@@ -16,6 +20,7 @@ describe("StepFunctionFromFile", () => {
     new StepFunctionFromFile<"__data__/">(stack, "MyStateMachine", {
       filepath: "__data__/test-machine.asl.yaml",
       baseDir: __dirname,
+      rootParentDir: ROOT_PARENT_DIR,
     });
   });
 
@@ -49,6 +54,7 @@ describe("StepFunctionFromFile", () => {
     new StepFunctionFromFile<"__data__/">(stack, "LambdaStateMachine", {
       filepath: "__data__/test-machine.asl.yaml",
       baseDir: __dirname,
+      rootParentDir: ROOT_PARENT_DIR,
       lambdaFunctions: [lambda, otherLambda],
       definitionSubstitutions: {
         ExtraParam: "ExtraValue",
@@ -80,5 +86,25 @@ describe("StepFunctionFromFile", () => {
         ]),
       },
     });
+  });
+
+  test("throws when filepath resolves outside the allowed root", () => {
+    expect(() => {
+      new StepFunctionFromFile<"__data__/">(stack, "BadPath", {
+        filepath: "__data__/../../../../../../etc/passwd" as `__data__/${string}`,
+        baseDir: __dirname,
+        rootParentDir: ROOT_PARENT_DIR,
+      });
+    }).toThrow(/Path traversal detected/);
+  });
+
+  test("throws when no matching rootParentDir ancestor exists", () => {
+    expect(() => {
+      new StepFunctionFromFile<"__data__/">(stack, "NoRoot", {
+        filepath: "__data__/test-machine.asl.yaml",
+        baseDir: __dirname,
+        rootParentDir: "nonexistent-parent",
+      });
+    }).toThrow(/Could not find a 'nonexistent-parent\/<name>' ancestor/);
   });
 });

--- a/packages/constructs/step-function-from-file/lib/step-function-from-file-construct.test.ts
+++ b/packages/constructs/step-function-from-file/lib/step-function-from-file-construct.test.ts
@@ -91,7 +91,8 @@ describe("StepFunctionFromFile", () => {
   test("throws when filepath resolves outside the allowed root", () => {
     expect(() => {
       new StepFunctionFromFile<"__data__/">(stack, "BadPath", {
-        filepath: "__data__/../../../../../../etc/passwd" as `__data__/${string}`,
+        filepath:
+          "__data__/../../../../../../etc/passwd" as `__data__/${string}`,
         baseDir: __dirname,
         rootParentDir: ROOT_PARENT_DIR,
       });

--- a/packages/constructs/step-function-from-file/lib/step-function-from-file-construct.ts
+++ b/packages/constructs/step-function-from-file/lib/step-function-from-file-construct.ts
@@ -85,7 +85,12 @@ export class StepFunctionFromFile<
     const definitionSubstitutionsObject =
       StepFunctionFromFile.prepareDefinitionSubstitutions(props);
 
-    const { filepath, baseDir, rootParentDir = "services", ...newProps } = {
+    const {
+      filepath,
+      baseDir,
+      rootParentDir = "services",
+      ...newProps
+    } = {
       ...props,
       ...definitionSubstitutionsObject,
     };

--- a/packages/constructs/step-function-from-file/lib/step-function-from-file-construct.ts
+++ b/packages/constructs/step-function-from-file/lib/step-function-from-file-construct.ts
@@ -10,7 +10,7 @@ import path from "path";
 export interface StepFunctionFromFileProps<
   TPrefix extends string = "infra/",
 > extends StateMachineProps {
-  readonly filepath: `${TPrefix}${string}`;
+  readonly filepath: `${NoInfer<TPrefix>}${string}`;
   readonly lambdaFunctions?: Function[];
   /**
    * Base directory to resolve `filepath` from.

--- a/packages/constructs/step-function-from-file/lib/step-function-from-file-construct.ts
+++ b/packages/constructs/step-function-from-file/lib/step-function-from-file-construct.ts
@@ -18,6 +18,12 @@ export interface StepFunctionFromFileProps<
    * so that `filepath` is resolved relative to the caller's location.
    */
   readonly baseDir: string;
+  /**
+   * Parent directory name used to determine the allowed root for path traversal.
+   * The allowed root is the first ancestor whose parent matches this name.
+   * @default `'services'`
+   */
+  readonly rootParentDir?: string;
 }
 
 /**
@@ -79,14 +85,15 @@ export class StepFunctionFromFile<
     const definitionSubstitutionsObject =
       StepFunctionFromFile.prepareDefinitionSubstitutions(props);
 
-    const { filepath, baseDir, ...newProps } = {
+    const { filepath, baseDir, rootParentDir = "services", ...newProps } = {
       ...props,
       ...definitionSubstitutionsObject,
     };
 
     const resolvedPath = StepFunctionFromFile.resolveAssetPath(
       filepath,
-      baseDir
+      baseDir,
+      rootParentDir
     );
 
     super(scope, id, {
@@ -125,14 +132,43 @@ export class StepFunctionFromFile<
   }
 
   /**
+   * Walks up from the given directory until it finds a path
+   * whose parent directory is named the given rootParentDir (e.g. `services/companies`).
+   */
+  private static findServiceRoot(dir: string, rootParentDir: string): string {
+    let current = path.resolve(dir);
+    const root = path.parse(current).root;
+
+    while (current !== root) {
+      if (path.basename(path.dirname(current)) === rootParentDir) {
+        return current;
+      }
+      current = path.dirname(current);
+    }
+
+    throw new Error(
+      `Could not find a '${rootParentDir}/<name>' ancestor from ${dir}`
+    );
+  }
+
+  /**
    * Resolves a path to assets relative to a given base directory.
    */
-  private static resolveAssetPath(assetPath: string, baseDir: string): string {
+  private static resolveAssetPath(
+    assetPath: string,
+    baseDir: string,
+    rootParentDir: string
+  ): string {
     const target = path.resolve(baseDir, assetPath);
-    const relative = path.relative(baseDir, target);
+    const allowedRoot = StepFunctionFromFile.findServiceRoot(
+      baseDir,
+      rootParentDir
+    );
 
-    if (relative.startsWith("..") || path.isAbsolute(relative)) {
-      throw new Error("Invalid file path");
+    if (!target.startsWith(allowedRoot + path.sep) && target !== allowedRoot) {
+      throw new Error(
+        `Path traversal detected: resolved path '${target}' is outside allowed root '${allowedRoot}'`
+      );
     }
 
     return target;


### PR DESCRIPTION
**Description of the proposed changes**  

* Adds NoInfer to template literal types in StepFunctionFromFile and NodejsFunctionFromEntry to fix generic inference
* Changes NodejsFunctionFromEntry base class from Function to NodejsFunction
* Replaces the simple `..` path traversal check with a `findServiceRoot` approach in both constructs

**Notes to reviewers**  

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback