### PR TITLE
fix: grant CloudWatch Logs delivery permissions in StepFunctionsDefaultsAspect

### DIFF
--- a/.changeset/fix-sfn-logging-grants.md
+++ b/.changeset/fix-sfn-logging-grants.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-aspects": patch
+---
+
+Fixed `StepFunctionsDefaultsAspect` missing IAM grants for CloudWatch Logs delivery. The aspect was setting `loggingConfiguration` directly on the L1 `CfnStateMachine`, bypassing CDK's IAM grant mechanism. The state machine role now receives the required `logs:*` permissions, preventing the `"IAM Role is not authorized to access the Log Destination"` CloudFormation error on deployment.

--- a/packages/cdk-aspects/lib/defaults/step-functions.test.ts
+++ b/packages/cdk-aspects/lib/defaults/step-functions.test.ts
@@ -1,0 +1,143 @@
+import { App, Aspects, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import {
+  DefinitionBody,
+  Pass,
+  StateMachine,
+  StateMachineType,
+} from "aws-cdk-lib/aws-stepfunctions";
+import { StepFunctionsDefaultsAspect } from "./step-functions";
+
+const makeStateMachine = (
+  stack: Stack,
+  id: string,
+  type: StateMachineType
+): StateMachine =>
+  new StateMachine(stack, id, {
+    stateMachineType: type,
+    definitionBody: DefinitionBody.fromChainable(new Pass(stack, `${id}Pass`)),
+  });
+
+describe("StepFunctionsDefaultsAspect", () => {
+  let app: App;
+  let stack: Stack;
+
+  beforeEach(() => {
+    app = new App();
+    stack = new Stack(app, "TestStack");
+    Aspects.of(stack).add(new StepFunctionsDefaultsAspect());
+  });
+
+  afterEach(() => {
+    app = undefined as unknown as App;
+    stack = undefined as unknown as Stack;
+  });
+
+  describe("X-Ray tracing", () => {
+    it("enables tracing on STANDARD state machines", () => {
+      makeStateMachine(stack, "StandardSM", StateMachineType.STANDARD);
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::StepFunctions::StateMachine",
+        { TracingConfiguration: { Enabled: true } }
+      );
+    });
+
+    it("enables tracing on EXPRESS state machines", () => {
+      makeStateMachine(stack, "ExpressSM", StateMachineType.EXPRESS);
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::StepFunctions::StateMachine",
+        { TracingConfiguration: { Enabled: true } }
+      );
+    });
+  });
+
+  describe("CloudWatch logging for EXPRESS machines", () => {
+    it("creates a log group and configures logging", () => {
+      makeStateMachine(stack, "ExpressSM", StateMachineType.EXPRESS);
+      app.synth();
+
+      const template = Template.fromStack(stack);
+
+      template.hasResourceProperties("AWS::Logs::LogGroup", {
+        LogGroupName: "/aws/vendedlogs/states/ExpressSM",
+      });
+
+      template.hasResourceProperties("AWS::StepFunctions::StateMachine", {
+        LoggingConfiguration: {
+          Level: "ALL",
+          IncludeExecutionData: true,
+          Destinations: Match.arrayWith([
+            Match.objectLike({
+              CloudWatchLogsLogGroup: {
+                LogGroupArn: Match.anyValue(),
+              },
+            }),
+          ]),
+        },
+      });
+    });
+
+    it("attaches CloudWatch Logs delivery permissions to the state machine role", () => {
+      makeStateMachine(stack, "ExpressSM", StateMachineType.EXPRESS);
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Effect: "Allow",
+              Action: Match.arrayWith([
+                "logs:CreateLogDelivery",
+                "logs:GetLogDelivery",
+                "logs:UpdateLogDelivery",
+                "logs:DeleteLogDelivery",
+                "logs:ListLogDeliveries",
+                "logs:PutResourcePolicy",
+                "logs:DescribeResourcePolicies",
+                "logs:DescribeLogGroups",
+              ]),
+              Resource: "*",
+            }),
+          ]),
+        },
+      });
+    });
+
+    it("does not configure logging for STANDARD state machines", () => {
+      makeStateMachine(stack, "StandardSM", StateMachineType.STANDARD);
+      app.synth();
+
+      const template = Template.fromStack(stack);
+
+      const machines = template.findResources(
+        "AWS::StepFunctions::StateMachine"
+      );
+      const props = Object.values(machines)[0].Properties;
+      expect(props.LoggingConfiguration).toBeUndefined();
+    });
+
+    it("does not override an existing logging configuration", () => {
+      const sm = makeStateMachine(stack, "ExpressSM", StateMachineType.EXPRESS);
+      const cfnSm = sm.node
+        .defaultChild as import("aws-cdk-lib/aws-stepfunctions").CfnStateMachine;
+      cfnSm.loggingConfiguration = {
+        level: "ERROR",
+        includeExecutionData: false,
+        destinations: [],
+      };
+
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::StepFunctions::StateMachine",
+        {
+          LoggingConfiguration: Match.objectLike({ Level: "ERROR" }),
+        }
+      );
+    });
+  });
+});

--- a/packages/cdk-aspects/lib/defaults/step-functions.ts
+++ b/packages/cdk-aspects/lib/defaults/step-functions.ts
@@ -1,5 +1,6 @@
 import { type IAspect } from "aws-cdk-lib";
-import { CfnLogGroup, LogGroup } from "aws-cdk-lib/aws-logs";
+import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { LogGroup } from "aws-cdk-lib/aws-logs";
 import {
   CfnStateMachine,
   LogLevel,
@@ -57,25 +58,46 @@ export class StepFunctionsDefaultsAspect implements IAspect {
           cfnStateMachine.stateMachineType === StateMachineType.EXPRESS &&
           cfnStateMachine.loggingConfiguration === undefined
         ) {
-          // Create a log group for the state machine
           const logGroup = new LogGroup(node, "LogGroup", {
             logGroupName: `/aws/vendedlogs/states/${node.node.id}`,
           });
-
-          // Get the underlying CFN log group to access its ARN
-          const cfnLogGroup = logGroup.node.defaultChild as CfnLogGroup;
 
           cfnStateMachine.loggingConfiguration = {
             destinations: [
               {
                 cloudWatchLogsLogGroup: {
-                  logGroupArn: cfnLogGroup.attrArn,
+                  logGroupArn: logGroup.logGroupArn,
                 },
               },
             ],
             level: LogLevel.ALL,
             includeExecutionData: true,
           };
+
+          // Grant the state machine role the permissions required to deliver logs.
+          // Mirrors what CDK's StateMachine.buildLoggingConfiguration() does internally.
+          //
+          // resources: ["*"] is intentional — all eight actions are vended-log-delivery
+          // control-plane APIs that operate at the account level and do not support
+          // resource-level scoping against a specific log group ARN.
+          // See: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatchlogs.html
+          //      https://docs.aws.amazon.com/step-functions/latest/dg/cw-logs.html
+          node.addToRolePolicy(
+            new PolicyStatement({
+              effect: Effect.ALLOW,
+              actions: [
+                "logs:CreateLogDelivery",
+                "logs:GetLogDelivery",
+                "logs:UpdateLogDelivery",
+                "logs:DeleteLogDelivery",
+                "logs:ListLogDeliveries",
+                "logs:PutResourcePolicy",
+                "logs:DescribeResourcePolicies",
+                "logs:DescribeLogGroups",
+              ],
+              resources: ["*"],
+            })
+          );
         }
       }
     }


### PR DESCRIPTION
**Description of the proposed changes**

`StepFunctionsDefaultsAspect` was configuring CloudWatch logging for Express state machines by setting `loggingConfiguration` directly on the `CfnStateMachine` (L1) construct. Because this bypasses the CDK L2 `StateMachine` API, CDK never attached the IAM policies the state machine role needs to deliver logs, resulting in a CloudFormation deployment error:

```
Resource handler returned message: "The state machine IAM Role is not authorized to access the Log Destination (Service: Sfn, Status Code: 400)"
```

**Changes**

- Replaced `cfnLogGroup.attrArn` (L1) with `logGroup.logGroupArn` (L2) for the logging destination ARN
- Added `node.addToRolePolicy()` with the 8 `logs:*` delivery permissions, mirroring what CDK's internal `StateMachine.buildLoggingConfiguration()` does
- `resources: ["*"]` is required — all eight actions are vended-log-delivery control-plane APIs that don't support resource-level scoping (documented in code with links to AWS IAM reference and Step Functions logging docs)
- Added `step-functions.test.ts` with 6 tests covering tracing, log group creation, the IAM grant, STANDARD machine exclusion, and idempotency

**Notes to reviewers**

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback