### PR TITLE
MI-317: Truncate and warn when prefixed resource names exceed AWS limits

### DIFF
--- a/.changeset/fix-resource-prefix-length-truncation.md
+++ b/.changeset/fix-resource-prefix-length-truncation.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-aspects": patch
+---
+
+Fixed `ResourcePrefixAspect` failing synthesis when a prefixed resource name exceeds the AWS maximum length. The aspect now truncates the name and appends an 8-character SHA-256 hash to maintain uniqueness, and emits a `cdk synth` warning identifying the original and truncated name. This prevents L3 constructs (e.g. `BucketDeployment`) from generating child resources that the user has no control over causing failed deployments.

--- a/packages/cdk-aspects/README.md
+++ b/packages/cdk-aspects/README.md
@@ -105,6 +105,64 @@ const stack = new Stack(app, "MyStack");
 Aspects.of(stack).add(new MicroserviceChecks());
 ```
 
+## Resource Prefix
+
+Automatically prefixes physical resource names across supported AWS resource types. Ensures all resources in a stack share a consistent naming scheme (e.g. `myapp-prod-orders-function`), which is especially useful for identifying resources by environment or service in the AWS console.
+
+### Features
+
+- Prefixes names for Lambda functions, S3 buckets, DynamoDB tables, SQS queues, SNS topics, IAM roles, SSM parameters, Step Functions, EventBridge rules, and more
+- Handles resource-specific naming rules: S3 names are lowercased, FIFO queues/topics preserve the `.fifo` suffix, SSM parameters use path-style prefixes (`/prefix/name`)
+- **Automatic truncation**: if a prefixed name would exceed AWS's maximum length for that resource type, the aspect truncates the name and appends an 8-character SHA-256 hash to maintain uniqueness. A CDK warning is emitted for each truncated resource. This prevents L3 constructs (e.g. `BucketDeployment`) from generating child resources that cause synthesis failures.
+- Idempotent: already-prefixed resources are skipped
+- Supports an exclusion list to skip specific resource types
+
+### Usage
+
+```typescript
+import { Aspects } from "aws-cdk-lib";
+import { ResourcePrefixAspect } from "@aligent/cdk-aspects";
+
+const stage = new ApplicationStage(app, "prod");
+Aspects.of(stage).add(new ResourcePrefixAspect({ prefix: "myapp-prod" }));
+```
+
+Excluding specific resource types:
+
+```typescript
+Aspects.of(stage).add(
+  new ResourcePrefixAspect({
+    prefix: "myapp-prod",
+    exclude: ["AWS::IAM::Role"],
+  })
+);
+```
+
+### Truncation behaviour
+
+When a prefixed name exceeds the AWS maximum for its resource type, the aspect:
+
+1. Hashes the full (pre-truncation) name with SHA-256 and takes the first 8 hex characters
+2. Truncates the name to fit within the limit, preserving any required suffix (e.g. `.fifo`)
+3. Emits a `cdk synth` warning identifying the original and truncated name
+
+This applies to all overflows, including explicitly user-set names. The warning tells you which resources were affected so you can shorten the base name or prefix if desired.
+
+Example warning:
+```
+[ResourcePrefixAspect] "myapp-prod-VeryLongGeneratedFunctionName" (72 chars) exceeds the maximum allowed length of 64. Name has been truncated to "myapp-prod-VeryLongGenerate-a3f9c2d1". Shorten the resource base name or your prefix ("myapp-prod") to avoid truncation.
+```
+
+### Critical notes
+
+- **Apply to each `Stage`, not the `App`**: CDK Stage constructs create synthesis boundaries. Apply the aspect to each Stage individually.
+- **Aspect priority with versioning**: when combining with `LambdaAndStepFunctionVersioningAspect`, apply this aspect first using CDK's priority system (lower number = runs first):
+
+```typescript
+Aspects.of(stage).add(new ResourcePrefixAspect({ prefix: "myapp" }), { priority: 100 });
+Aspects.of(stage).add(new LambdaAndStepFunctionVersioningAspect(), { priority: 200 });
+```
+
 ## Version Functions
 
 An aspect that automatically adds versioning and aliases to Lambda functions and Step Functions.

--- a/packages/cdk-aspects/lib/resource-prefix.test.ts
+++ b/packages/cdk-aspects/lib/resource-prefix.test.ts
@@ -1,5 +1,6 @@
+import { createHash } from "crypto";
 import { App, Aspects, Stack } from "aws-cdk-lib";
-import { Match, Template } from "aws-cdk-lib/assertions";
+import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { AttributeType, Table } from "aws-cdk-lib/aws-dynamodb";
 import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { CfnFunction } from "aws-cdk-lib/aws-lambda";
@@ -220,6 +221,110 @@ describe("ResourcePrefixAspect", () => {
       const functionName = Object.values(resources)[0].Properties
         .FunctionName as string;
       expect(functionName).toMatch(/^myapp-/);
+    });
+  });
+
+  describe("truncation", () => {
+    // Lambda maxLength = 64. With prefix "myapp-" (6 chars), the construct ID must be
+    // > 58 chars so the prefixed name exceeds the limit. Using logical ID (construct ID)
+    // as the name source avoids relying on CDK's internal _cfnProperties API.
+    const longLambdaId =
+      "FunctionWithAVeryLongNameThatWillExceedTheLimitOfSixtyFourChars"; // 63 chars → prefixed = 69
+
+    it("should truncate a Lambda name that exceeds 64 chars and emit a warning", () => {
+      new CfnFunction(stack, longLambdaId, {
+        runtime: "nodejs22.x",
+        handler: "index.handler",
+        code: { zipFile: "exports.handler = () => {};" },
+        role: "arn:aws:iam::123456789012:role/test",
+      });
+
+      app.synth();
+
+      const template = Template.fromStack(stack);
+      const resources = template.findResources("AWS::Lambda::Function");
+      const functionName = Object.values(resources)[0].Properties
+        .FunctionName as string;
+
+      expect(functionName.length).toBeLessThanOrEqual(64);
+      expect(functionName).toMatch(/^myapp-/);
+      expect(functionName).toMatch(/-[0-9a-f]{8}$/);
+
+      Annotations.fromStack(stack).hasWarning(
+        `/TestStack/${longLambdaId}`,
+        Match.stringLikeRegexp("\\[ResourcePrefixAspect\\].*truncated.*")
+      );
+    });
+
+    it("should produce a deterministic truncated name", () => {
+      const fullName = `myapp-${longLambdaId}`;
+      const hash = createHash("sha256")
+        .update(fullName)
+        .digest("hex")
+        .slice(0, 8);
+      const budget = 64 - 8 - 1; // maxLength - hash length - dash separator
+      const expected = fullName.slice(0, budget) + "-" + hash;
+
+      new CfnFunction(stack, longLambdaId, {
+        runtime: "nodejs22.x",
+        handler: "index.handler",
+        code: { zipFile: "exports.handler = () => {};" },
+        role: "arn:aws:iam::123456789012:role/test",
+      });
+
+      app.synth();
+
+      const template = Template.fromStack(stack);
+      const resources = template.findResources("AWS::Lambda::Function");
+      const functionName = Object.values(resources)[0].Properties
+        .FunctionName as string;
+
+      expect(functionName).toBe(expected);
+    });
+
+    it("should truncate a long FIFO queue name and preserve the .fifo suffix", () => {
+      // SQS maxLength = 80. With "myapp-" (6) + id + ".fifo" (5), id must be > 69 chars.
+      const longFifoId =
+        "FifoQueueWithAVeryLongNameThatWillExceedTheEightyCharLimitForSqsQueues"; // 70 chars → prefixed+.fifo = 81
+
+      new CfnQueue(stack, longFifoId, { fifoQueue: true });
+
+      app.synth();
+
+      const template = Template.fromStack(stack);
+      const resources = template.findResources("AWS::SQS::Queue");
+      const queueName = Object.values(resources)[0].Properties
+        .QueueName as string;
+
+      expect(queueName.length).toBeLessThanOrEqual(80);
+      expect(queueName).toMatch(/^myapp-/);
+      expect(queueName).toMatch(/\.fifo$/);
+
+      Annotations.fromStack(stack).hasWarning(
+        `/TestStack/${longFifoId}`,
+        Match.stringLikeRegexp("\\[ResourcePrefixAspect\\].*truncated.*")
+      );
+    });
+
+    it("should not truncate names that are within the limit", () => {
+      new CfnFunction(stack, "ShortFunction", {
+        runtime: "nodejs22.x",
+        handler: "index.handler",
+        code: { zipFile: "exports.handler = () => {};" },
+        role: "arn:aws:iam::123456789012:role/test",
+      });
+
+      app.synth();
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::Lambda::Function", {
+        FunctionName: "myapp-ShortFunction",
+      });
+
+      Annotations.fromStack(stack).hasNoWarning(
+        "/TestStack/ShortFunction",
+        Match.stringLikeRegexp(".*truncated.*")
+      );
     });
   });
 });

--- a/packages/cdk-aspects/lib/resource-prefix.ts
+++ b/packages/cdk-aspects/lib/resource-prefix.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { Annotations, CfnResource, IAspect, Stack } from "aws-cdk-lib";
 import { IConstruct } from "constructs";
 
@@ -174,18 +175,17 @@ export class ResourcePrefixAspect implements IAspect {
       return;
     }
 
-    const finalName = this.buildPrefixedName(
+    const prefixedName = this.buildPrefixedName(
       baseName,
       resourceType,
       cfnProperties
     );
 
-    const hasError = this.validateResourceName(
-      finalName,
-      resourceType,
-      maxLength,
-      node
-    );
+    // Truncation applies to all overflows — including user-set names — because L3
+    // constructs can generate names the user has no direct control over.
+    const finalName = this.truncateToFit(prefixedName, maxLength, node);
+
+    const hasError = this.validateResourceName(finalName, resourceType, node);
 
     if (hasError) return;
 
@@ -251,18 +251,45 @@ export class ResourcePrefixAspect implements IAspect {
   }
 
   /**
-   * Validates resource-specific naming requirements that AWS enforces.
-   * Throws synthesis errors for violations.
+   * Truncates a prefixed name to fit within maxLength by hashing the original
+   * for uniqueness. Emits a CDK warning when truncation occurs.
+   */
+  private truncateToFit(
+    name: string,
+    maxLength: number,
+    node: IConstruct
+  ): string {
+    if (name.length <= maxLength) return name;
+
+    const hash = createHash("sha256").update(name).digest("hex").slice(0, 8);
+
+    // Preserve .fifo suffix — AWS requires it at the end of FIFO resource names
+    const suffix = name.endsWith(".fifo") ? ".fifo" : "";
+    const nameWithoutSuffix = suffix ? name.slice(0, -suffix.length) : name;
+
+    // 1 accounts for the dash separator before the hash
+    const budget = maxLength - hash.length - 1 - suffix.length;
+    const truncated = nameWithoutSuffix.slice(0, budget) + "-" + hash + suffix;
+
+    Annotations.of(node).addWarning(
+      `[ResourcePrefixAspect] "${name}" (${name.length} chars) exceeds the maximum allowed length of ${maxLength}. ` +
+        `Name has been truncated to "${truncated}". Shorten the resource base name or your prefix ("${this.prefix}") to avoid truncation.`
+    );
+
+    return truncated;
+  }
+
+  /**
+   * Validates resource-specific structural naming requirements that AWS enforces.
+   * Length violations are handled upstream by truncateToFit.
    */
   private validateResourceName(
     name: string,
     cfnResourceType: string,
-    maxLength: number,
     node: IConstruct
   ): boolean {
     let hasError = false;
 
-    // S3 bucket names cannot contain underscores
     if (cfnResourceType === "AWS::S3::Bucket") {
       if (name !== name.toLowerCase()) {
         Annotations.of(node).addError(
@@ -279,15 +306,6 @@ export class ResourcePrefixAspect implements IAspect {
         );
         hasError = true;
       }
-    }
-
-    if (name.length > maxLength) {
-      Annotations.of(node).addError(
-        `[ResourcePrefixAspect] "${name}" (${name.length} chars) exceeds the ` +
-          `maximum allowed length of ${maxLength} for ${cfnResourceType}. ` +
-          `Shorten the resource base name or your prefix ("${this.prefix}").`
-      );
-      hasError = true;
     }
 
     return hasError;


### PR DESCRIPTION
**Description of the proposed changes**

* Replaces the synthesis error thrown when a prefixed resource name exceeds the AWS maximum length with automatic truncation — the aspect now truncates the name and appends an 8-character SHA-256 hash to maintain uniqueness
* Emits a `cdk synth` warning (via `Annotations.of(node).addWarning()`) for each truncated resource, identifying the original and truncated name so users can shorten their prefix or base name if desired
* Adds a `truncateToFit` private method that handles suffix-aware truncation (preserving `.fifo` for FIFO queues/topics); `validateResourceName` now only handles S3 structural checks (uppercase, underscores)
* Adds four new tests covering: warning emission, deterministic output, FIFO suffix preservation, and no-truncation for short names
* Documents the truncation behaviour and `ResourcePrefixAspect` usage in the package README

**Notes to reviewers**

🛈  When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback