### PR TITLE
DO-2019: replace deprecated S3Origin with S3BucketOrigin

### DIFF
--- a/.changeset/replace-deprecated-s3origin.md
+++ b/.changeset/replace-deprecated-s3origin.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-static-hosting": patch
+---
+
+Replaced deprecated `S3Origin` with `S3BucketOrigin.withOriginAccessIdentity` to silence the `aws-cdk-lib.aws_cloudfront_origins.S3Origin is deprecated` warning. No behavioural change — the same OAI is still used.

--- a/packages/constructs/static-hosting/lib/static-hosting.ts
+++ b/packages/constructs/static-hosting/lib/static-hosting.ts
@@ -25,7 +25,7 @@ import {
   SSLMethod,
   ViewerProtocolPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
-import { HttpOrigin, S3Origin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { HttpOrigin, S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import {
   Effect,
   Group,
@@ -557,7 +557,7 @@ export class StaticHosting extends Construct {
       });
     }
 
-    const s3Origin = new S3Origin(this.bucket, {
+    const s3Origin = S3BucketOrigin.withOriginAccessIdentity(this.bucket, {
       originAccessIdentity: this.oai,
     });
     let backendOrigin = undefined;


### PR DESCRIPTION
**Description of the proposed changes**

Replaces the deprecated `aws-cdk-lib.aws_cloudfront_origins.S3Origin` with `S3BucketOrigin.withOriginAccessIdentity` in `static-hosting`. This silences the synth-time warning:

```
[WARNING] aws-cdk-lib.aws_cloudfront_origins.S3Origin is deprecated.
  Use `S3BucketOrigin` or `S3StaticWebsiteOrigin` instead.
```

No behavioural change — the same Origin Access Identity is passed through, so the generated CloudFront/S3 wiring is equivalent.

**Notes to reviewers**

- `static-hosting` was the only package using `S3Origin`.
- AWS recommends OAC over OAI for new work, but switching to OAC would be a breaking change for existing stacks (it rewrites the bucket policy and removes the OAI). Kept on OAI here to stay drop-in; an OAC migration can be done separately if desired.
- Existing tests (69) still pass with no snapshot changes required.

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback