### PR TITLE
feat: add SecureRestApi construct for API Gateway REST APIs with API key authentication and usage plan throttling

### DIFF
--- a/.changeset/add-secure-rest-api.md
+++ b/.changeset/add-secure-rest-api.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-secure-rest-api": minor
+---
+
+Add new `SecureRestApi` construct for provisioning an API Gateway REST API secured with API key authentication and usage plan throttling. Supports configurable routes (accepting any CDK `Integration`), CORS options, and throttle limits.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ These are all written for CDK v2. See the official AWS guide for how to migrate 
 | [prerender-fargate](packages/constructs/prerender-fargate)                     | Self-hosted prerender to handle prerender bot requests                                                                       |
 | [prerender-proxy](packages/constructs/prerender-proxy)                         | Provides functions to adjust self-hosted prerender behaviour                                                                 |
 | [rabbitmq](packages/constructs/rabbitmq)                                       | Create a RabbitMQ cluster within CDK                                                                                         |
+| [secure-rest-api](packages/constructs/secure-rest-api)                         | API Gateway REST API secured with API key authentication and usage plan throttling                                            |
 | [shared-vpc](packages/constructs/shared-vpc)                                   | Creates a single VPC with static IP for micro-services with DNS management                                                   |
 | [static-hosting](packages/constructs/static-hosting)                           | Construct to deploy infrastructure for static webpage hosting                                                                |
 | [step-function-from-file](packages/constructs/step-function-from-file)         | Create a Step Function state machine definition from a given JSON or YAML file                                               |

--- a/packages/constructs/secure-rest-api/README.md
+++ b/packages/constructs/secure-rest-api/README.md
@@ -93,9 +93,9 @@ const api = new SecureRestApi(this, 'Api', {
 const api = new SecureRestApi(this, 'Api', {
   apiName: 'my-api',
   corsOptions: {
-    allowOrigins: ['https://example.com'],
-    allowMethods: ['GET', 'POST', 'OPTIONS'],
-    allowHeaders: ['Content-Type', 'X-Api-Key', 'Authorization'],
+    allowOrigins: ['https://example.com'],  // overrides default (all origins)
+    additionalMethods: ['POST'],            // appended to GET, OPTIONS
+    additionalHeaders: ['Authorization'],   // appended to Content-Type, X-Api-Key
   },
   routes: [...],
 });
@@ -136,11 +136,11 @@ Throttling limits applied to the usage plan.
 
 CORS preflight configuration applied to all resources.
 
-| Property | Type | Default |
-|----------|------|---------|
-| `allowOrigins` | `string[]` | All origins |
-| `allowMethods` | `string[]` | `['GET', 'OPTIONS']` |
-| `allowHeaders` | `string[]` | `['Content-Type', 'X-Api-Key']` |
+| Property | Type | Behaviour |
+|----------|------|-----------|
+| `allowOrigins` | `string[]` | Overrides the default (all origins) |
+| `additionalMethods` | `string[]` | Appended to the defaults: `GET`, `OPTIONS` |
+| `additionalHeaders` | `string[]` | Appended to the defaults: `Content-Type`, `X-Api-Key` |
 
 ### `apiKeyName` (string)
 

--- a/packages/constructs/secure-rest-api/README.md
+++ b/packages/constructs/secure-rest-api/README.md
@@ -1,0 +1,166 @@
+# Aligent AWS Secure REST API
+
+## Overview
+
+![TypeScript version](https://img.shields.io/github/package-json/dependency-version/aligent/cdk-constructs/dev/typescript?filename=packages/constructs/secure-rest-api/package.json&color=red) ![AWS CDK version](https://img.shields.io/github/package-json/dependency-version/aligent/cdk-constructs/dev/aws-cdk?filename=packages/constructs/secure-rest-api/package.json) ![NPM version](https://img.shields.io/npm/v/%40aligent%2Fcdk-secure-rest-api?color=green)
+
+A CDK construct for provisioning an API Gateway REST API secured with API Key authentication and usage plan throttling. Routes accept any CDK `Integration`, giving callers full control over how endpoints are wired.
+
+## Features
+
+- API Gateway REST API with API Key authentication (`apiKeyRequired: true` on all routes)
+- Usage plan with configurable throttle rate and burst limits
+- Configurable CORS preflight options
+- Accepts any CDK `Integration` per route (Lambda, HTTP, Mock, Step Functions, etc.)
+
+## Installation
+
+```bash
+npm install @aligent/cdk-secure-rest-api
+```
+
+Or with yarn:
+
+```bash
+yarn add @aligent/cdk-secure-rest-api aws-cdk-lib constructs
+```
+
+### Peer Dependencies
+
+- `aws-cdk-lib` (^2.113.0)
+- `constructs` (^10.5.0)
+
+## Basic Usage
+
+```typescript
+import { SecureRestApi } from '@aligent/cdk-secure-rest-api';
+import { LambdaIntegration } from 'aws-cdk-lib/aws-apigateway';
+import { HttpMethod } from 'aws-cdk-lib/aws-apigatewayv2';
+
+const api = new SecureRestApi(this, 'Api', {
+  apiName: 'my-api',
+  routes: [
+    {
+      path: 'items',
+      methods: [HttpMethod.GET],
+      integration: new LambdaIntegration(myFunction),
+    },
+  ],
+});
+
+// Access created resources
+const { api, apiKey, usagePlan } = api;
+```
+
+## Configuration Examples
+
+### Multiple routes and methods
+
+```typescript
+const api = new SecureRestApi(this, 'Api', {
+  apiName: 'my-api',
+  routes: [
+    {
+      path: 'items',
+      methods: [HttpMethod.GET, HttpMethod.POST],
+      integration: new LambdaIntegration(itemsFunction),
+    },
+    {
+      path: 'orders',
+      methods: [HttpMethod.GET],
+      integration: new LambdaIntegration(ordersFunction),
+    },
+  ],
+});
+```
+
+### Custom throttling
+
+```typescript
+const api = new SecureRestApi(this, 'Api', {
+  apiName: 'my-api',
+  throttle: {
+    rateLimit: 50,   // requests per second
+    burstLimit: 100,
+  },
+  routes: [...],
+});
+```
+
+### Custom CORS configuration
+
+```typescript
+const api = new SecureRestApi(this, 'Api', {
+  apiName: 'my-api',
+  corsOptions: {
+    allowOrigins: ['https://example.com'],
+    allowMethods: ['GET', 'POST', 'OPTIONS'],
+    allowHeaders: ['Content-Type', 'X-Api-Key', 'Authorization'],
+  },
+  routes: [...],
+});
+```
+
+## Configuration Reference
+
+### `apiName` (string) — required
+
+The name of the REST API and the base for generated resource names.
+
+### `description` (string)
+
+Description for the API Gateway REST API.
+
+Default: `REST API for {apiName} service`
+
+### `routes` (SecureRestApiRoute[]) — required
+
+Routes to register on the API. Each route requires:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `path` | `string` | The resource path (leading slash is stripped automatically) |
+| `methods` | `HttpMethod[]` | HTTP methods to register on the resource |
+| `integration` | `Integration` | Any CDK API Gateway integration |
+
+### `throttle` (object)
+
+Throttling limits applied to the usage plan.
+
+| Property | Type | Default |
+|----------|------|---------|
+| `rateLimit` | `number` | `100` |
+| `burstLimit` | `number` | `200` |
+
+### `corsOptions` (object)
+
+CORS preflight configuration applied to all resources.
+
+| Property | Type | Default |
+|----------|------|---------|
+| `allowOrigins` | `string[]` | All origins |
+| `allowMethods` | `string[]` | `['GET', 'OPTIONS']` |
+| `allowHeaders` | `string[]` | `['Content-Type', 'X-Api-Key']` |
+
+### `apiKeyName` (string)
+
+Override the name of the generated API key.
+
+Default: `{apiName}-api-key`
+
+### `usagePlanName` (string)
+
+Override the name of the generated usage plan.
+
+Default: `{apiName}-usage-plan`
+
+## Local Development
+
+[NPM link](https://docs.npmjs.com/cli/v7/commands/npm-link) can be used to develop the module locally:
+
+1. Pull this repository locally
+2. `cd` into this repository
+3. Run `npm link`
+4. `cd` into the downstream repo and run `npm link '@aligent/cdk-secure-rest-api'`
+
+The downstream repository should now include a symlink to this module, allowing local changes to be tested before pushing.

--- a/packages/constructs/secure-rest-api/index.ts
+++ b/packages/constructs/secure-rest-api/index.ts
@@ -1,0 +1,7 @@
+import {
+  SecureRestApi,
+  SecureRestApiProps,
+  SecureRestApiRoute,
+} from "./lib/secure-rest-api";
+
+export { SecureRestApi, SecureRestApiProps, SecureRestApiRoute };

--- a/packages/constructs/secure-rest-api/jest.config.ts
+++ b/packages/constructs/secure-rest-api/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: "secure-rest-api",
+  preset: "../../../jest.preset.js",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }],
+  },
+  moduleFileExtensions: ["ts", "js", "html"],
+  coverageDirectory: "../../../coverage/packages/secure-rest-api",
+};

--- a/packages/constructs/secure-rest-api/lib/secure-rest-api.test.ts
+++ b/packages/constructs/secure-rest-api/lib/secure-rest-api.test.ts
@@ -240,11 +240,44 @@ describe("SecureRestApi", () => {
       );
     });
 
-    it("applies custom CORS allow-origins", () => {
+    it("appends additionalHeaders to the defaults", () => {
       const { stack } = createStack();
       new SecureRestApi(stack, "Api", {
         apiName: "my-api",
-        corsOptions: { allowOrigins: ["https://example.com"] },
+        corsOptions: { additionalHeaders: ["Authorization"] },
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      // OPTIONS mock integration response headers include the allow-headers value
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::Method",
+        {
+          HttpMethod: "OPTIONS",
+          Integration: {
+            IntegrationResponses: [
+              {
+                ResponseParameters: {
+                  "method.response.header.Access-Control-Allow-Headers":
+                    "'Content-Type,X-Api-Key,Authorization'",
+                },
+              },
+            ],
+          },
+        }
+      );
+    });
+
+    it("appends additionalMethods to the defaults", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        corsOptions: { additionalMethods: ["POST"] },
         routes: [
           {
             path: "items",
@@ -256,7 +289,19 @@ describe("SecureRestApi", () => {
 
       Template.fromStack(stack).hasResourceProperties(
         "AWS::ApiGateway::Method",
-        { HttpMethod: "OPTIONS" }
+        {
+          HttpMethod: "OPTIONS",
+          Integration: {
+            IntegrationResponses: [
+              {
+                ResponseParameters: {
+                  "method.response.header.Access-Control-Allow-Methods":
+                    "'GET,OPTIONS,POST'",
+                },
+              },
+            ],
+          },
+        }
       );
     });
   });

--- a/packages/constructs/secure-rest-api/lib/secure-rest-api.test.ts
+++ b/packages/constructs/secure-rest-api/lib/secure-rest-api.test.ts
@@ -1,0 +1,263 @@
+import { App, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { LambdaIntegration, MockIntegration } from "aws-cdk-lib/aws-apigateway";
+import { HttpMethod } from "aws-cdk-lib/aws-apigatewayv2";
+import { Function, InlineCode, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+import { SecureRestApi } from "./secure-rest-api";
+
+const createStack = () => {
+  const app = new App();
+  const stack = new Stack(app, "TestStack");
+  return { app, stack };
+};
+
+const mockIntegration = () =>
+  new MockIntegration({
+    integrationResponses: [{ statusCode: "200" }],
+  });
+
+const lambdaIntegration = (scope: Construct) => {
+  const fn = new Function(scope, "Handler", {
+    runtime: Runtime.NODEJS_22_X,
+    handler: "index.handler",
+    code: InlineCode.fromInline("exports.handler = () => {}"),
+  });
+  return new LambdaIntegration(fn);
+};
+
+describe("SecureRestApi", () => {
+  describe("API Gateway", () => {
+    it("creates a REST API with the given name", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::RestApi",
+        { Name: "my-api" }
+      );
+    });
+
+    it("uses the provided description", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        description: "Custom description",
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::RestApi",
+        { Description: "Custom description" }
+      );
+    });
+
+    it("registers each route method with apiKeyRequired", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET, HttpMethod.POST],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::ApiGateway::Method", {
+        HttpMethod: "GET",
+        ApiKeyRequired: true,
+      });
+      template.hasResourceProperties("AWS::ApiGateway::Method", {
+        HttpMethod: "POST",
+        ApiKeyRequired: true,
+      });
+    });
+
+    it("accepts a LambdaIntegration as route integration", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: lambdaIntegration(stack),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).resourceCountIs("AWS::Lambda::Function", 1);
+    });
+  });
+
+  describe("API Key", () => {
+    it("creates an API key with a default name", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::ApiKey",
+        { Name: "my-api-api-key" }
+      );
+    });
+
+    it("uses a custom API key name when provided", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        apiKeyName: "custom-key",
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::ApiKey",
+        { Name: "custom-key" }
+      );
+    });
+  });
+
+  describe("Usage Plan", () => {
+    it("creates a usage plan with default throttle settings", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::UsagePlan",
+        {
+          Throttle: {
+            BurstLimit: 200,
+            RateLimit: 100,
+          },
+        }
+      );
+    });
+
+    it("uses custom throttle settings when provided", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        throttle: { rateLimit: 50, burstLimit: 100 },
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::UsagePlan",
+        {
+          Throttle: {
+            BurstLimit: 100,
+            RateLimit: 50,
+          },
+        }
+      );
+    });
+
+    it("uses a custom usage plan name when provided", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        usagePlanName: "custom-plan",
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::UsagePlan",
+        { UsagePlanName: "custom-plan" }
+      );
+    });
+  });
+
+  describe("CORS", () => {
+    it("applies default CORS settings", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::Method",
+        { HttpMethod: "OPTIONS" }
+      );
+    });
+
+    it("applies custom CORS allow-origins", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        corsOptions: { allowOrigins: ["https://example.com"] },
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::Method",
+        { HttpMethod: "OPTIONS" }
+      );
+    });
+  });
+});

--- a/packages/constructs/secure-rest-api/lib/secure-rest-api.ts
+++ b/packages/constructs/secure-rest-api/lib/secure-rest-api.ts
@@ -1,0 +1,121 @@
+import {
+  ApiKey,
+  Cors,
+  Integration,
+  IRestApi,
+  RestApi,
+  UsagePlan,
+} from "aws-cdk-lib/aws-apigateway";
+import { HttpMethod } from "aws-cdk-lib/aws-apigatewayv2";
+import { Construct } from "constructs";
+
+export interface SecureRestApiRoute {
+  path: string;
+  methods: HttpMethod[];
+  integration: Integration;
+}
+
+export interface SecureRestApiProps {
+  /**
+   * The name of the API.
+   */
+  apiName: string;
+
+  /**
+   * Description for the API.
+   */
+  description?: string;
+
+  /**
+   * CORS configuration.
+   * @default Allows all origins, GET/OPTIONS methods, Content-Type and X-Api-Key headers
+   */
+  corsOptions?: {
+    allowOrigins?: string[];
+    allowMethods?: string[];
+    allowHeaders?: string[];
+  };
+
+  /**
+   * Routes to register on the API.
+   */
+  routes: SecureRestApiRoute[];
+
+  /**
+   * Throttling limits for the usage plan.
+   * @default { rateLimit: 100, burstLimit: 200 }
+   */
+  throttle?: {
+    rateLimit: number;
+    burstLimit: number;
+  };
+
+  /**
+   * Override the generated API key name.
+   * @default `{apiName}-api-key`
+   */
+  apiKeyName?: string;
+
+  /**
+   * Override the generated usage plan name.
+   * @default `{apiName}-usage-plan`
+   */
+  usagePlanName?: string;
+}
+
+export class SecureRestApi extends Construct {
+  public readonly api: RestApi;
+  public readonly apiKey: ApiKey;
+  public readonly usagePlan: UsagePlan;
+
+  constructor(scope: Construct, id: string, props: SecureRestApiProps) {
+    super(scope, id);
+
+    const {
+      apiName,
+      description,
+      corsOptions,
+      routes,
+      throttle = { rateLimit: 100, burstLimit: 200 },
+      apiKeyName,
+      usagePlanName,
+    } = props;
+
+    this.api = new RestApi(this, "Api", {
+      restApiName: apiName,
+      description: description ?? `REST API for ${apiName} service`,
+      defaultCorsPreflightOptions: {
+        allowOrigins: corsOptions?.allowOrigins ?? Cors.ALL_ORIGINS,
+        allowMethods: corsOptions?.allowMethods ?? ["GET", "OPTIONS"],
+        allowHeaders: corsOptions?.allowHeaders ?? [
+          "Content-Type",
+          "X-Api-Key",
+        ],
+      },
+    });
+
+    for (const route of routes) {
+      const resource = this.api.root.addResource(route.path.replace(/^\//, ""));
+      for (const method of route.methods) {
+        resource.addMethod(method, route.integration, { apiKeyRequired: true });
+      }
+    }
+
+    this.apiKey = new ApiKey(this, "ApiKey", {
+      description: `API Key for ${apiName} service`,
+      apiKeyName: apiKeyName ?? `${apiName}-api-key`,
+    });
+
+    this.usagePlan = new UsagePlan(this, "UsagePlan", {
+      name: usagePlanName ?? `${apiName}-usage-plan`,
+      description: `Usage plan for ${apiName} service`,
+      throttle,
+    });
+
+    this.usagePlan.addApiStage({
+      api: this.api as IRestApi,
+      stage: this.api.deploymentStage,
+    });
+    this.usagePlan.addApiKey(this.apiKey);
+  }
+}

--- a/packages/constructs/secure-rest-api/lib/secure-rest-api.ts
+++ b/packages/constructs/secure-rest-api/lib/secure-rest-api.ts
@@ -28,12 +28,15 @@ export interface SecureRestApiProps {
 
   /**
    * CORS configuration.
-   * @default Allows all origins, GET/OPTIONS methods, Content-Type and X-Api-Key headers
+   *
+   * `allowOrigins` overrides the default (all origins).
+   * `additionalMethods` and `additionalHeaders` are appended to the defaults
+   * (GET/OPTIONS and Content-Type/X-Api-Key respectively).
    */
   corsOptions?: {
     allowOrigins?: string[];
-    allowMethods?: string[];
-    allowHeaders?: string[];
+    additionalMethods?: string[];
+    additionalHeaders?: string[];
   };
 
   /**
@@ -86,10 +89,15 @@ export class SecureRestApi extends Construct {
       description: description ?? `REST API for ${apiName} service`,
       defaultCorsPreflightOptions: {
         allowOrigins: corsOptions?.allowOrigins ?? Cors.ALL_ORIGINS,
-        allowMethods: corsOptions?.allowMethods ?? ["GET", "OPTIONS"],
-        allowHeaders: corsOptions?.allowHeaders ?? [
+        allowMethods: [
+          "GET",
+          "OPTIONS",
+          ...(corsOptions?.additionalMethods ?? []),
+        ],
+        allowHeaders: [
           "Content-Type",
           "X-Api-Key",
+          ...(corsOptions?.additionalHeaders ?? []),
         ],
       },
     });

--- a/packages/constructs/secure-rest-api/package.json
+++ b/packages/constructs/secure-rest-api/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@aligent/cdk-secure-rest-api",
+  "version": "1.0.0",
+  "description": "A CDK construct for creating API Gateway REST APIs secured with API Key authentication and usage plan throttling",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "license": "MIT",
+  "homepage": "https://github.com/aligent/cdk-constructs/tree/main/packages/constructs/secure-rest-api#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aligent/cdk-constructs.git"
+  },
+  "bugs": {
+    "url": "https://github.com/aligent/cdk-constructs/issues"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "npx nx test secure-rest-api",
+    "lint": "npx nx lint secure-rest-api"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.10",
+    "@types/node": "^20.19.39",
+    "aws-cdk": "^2.1119.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.3.2"
+  },
+  "dependencies": {
+    "source-map-support": "^0.5.21"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.113.0",
+    "constructs": "^10.5.0"
+  }
+}

--- a/packages/constructs/secure-rest-api/project.json
+++ b/packages/constructs/secure-rest-api/project.json
@@ -1,0 +1,36 @@
+{
+  "name": "secure-rest-api",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/constructs/secure-rest-api/lib",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --project tsconfig.app.json",
+        "cwd": "packages/constructs/secure-rest-api"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "packages/constructs/secure-rest-api/jest.config.ts",
+        "passWithNoTests": true
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm publish --access public",
+        "cwd": "packages/constructs/secure-rest-api"
+      },
+      "dependsOn": ["build"]
+    }
+  },
+  "tags": []
+}

--- a/packages/constructs/secure-rest-api/tsconfig.app.json
+++ b/packages/constructs/secure-rest-api/tsconfig.app.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": ".",
+    "rootDir": ".",
+    "module": "commonjs",
+    "types": ["node"]
+  },
+  "exclude": ["./jest.config.ts", "**/*.test.ts", "**/*.spec.ts"],
+  "include": ["lib/**/*.ts", "index.ts"]
+}

--- a/packages/constructs/secure-rest-api/tsconfig.json
+++ b/packages/constructs/secure-rest-api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/packages/constructs/secure-rest-api/tsconfig.spec.json
+++ b/packages/constructs/secure-rest-api/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,6 +287,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@aligent/cdk-secure-rest-api@workspace:packages/constructs/secure-rest-api":
+  version: 0.0.0-use.local
+  resolution: "@aligent/cdk-secure-rest-api@workspace:packages/constructs/secure-rest-api"
+  dependencies:
+    "@types/jest": "npm:^29.5.10"
+    "@types/node": "npm:^20.19.39"
+    aws-cdk: "npm:^2.1119.0"
+    jest: "npm:^29.7.0"
+    source-map-support: "npm:^0.5.21"
+    ts-jest: "npm:^29.4.9"
+    ts-node: "npm:^10.9.1"
+    typescript: "npm:^5.3.2"
+  peerDependencies:
+    aws-cdk-lib: ^2.113.0
+    constructs: ^10.5.0
+  languageName: unknown
+  linkType: soft
+
 "@aligent/cdk-shared-vpc@workspace:packages/constructs/shared-vpc":
   version: 0.0.0-use.local
   resolution: "@aligent/cdk-shared-vpc@workspace:packages/constructs/shared-vpc"


### PR DESCRIPTION
**Description of the proposed changes**

* Adds new `@aligent/cdk-secure-rest-api` package providing a `SecureRestApi` CDK construct
* Creates an API Gateway REST API with API key authentication (`apiKeyRequired: true`) and usage plan throttling on all routes
* Routes accept any CDK `Integration` (Lambda, HTTP, Mock, Step Functions, etc.) rather than hardcoding a specific integration type, giving callers full control over how endpoints are wired
* Configurable CORS preflight options, throttle rate/burst limits, and name overrides for the API key and usage plan
* Adds the construct to the root README

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them 
know that you have finished leaving feedback

**Toggl**

`AP21INT-28: Code Review API`