### PR TITLE
fix(cdk-aspects): prevent DynamoDbDefaultsAspect injecting incompatible throughput settings

### DIFF
--- a/.changeset/fix-dynamo-defaults-aspect-billing-mode.md
+++ b/.changeset/fix-dynamo-defaults-aspect-billing-mode.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-aspects": patch
+---
+
+Fix `DynamoDbDefaultsAspect` injecting `ProvisionedThroughput` onto `PAY_PER_REQUEST` tables and `OnDemandThroughput` onto `PROVISIONED` tables

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,26 @@ yarn nx lint <package-name> --fix
 6. Push to remote
 
 **Never push code that fails linting checks** - this will cause GitHub Actions to fail and block the PR.
+
+### Changesets
+
+This repo uses [Changesets](https://github.com/changesets/changesets) for versioning. Every PR that modifies a package must include a changeset file in `.changeset/`.
+
+Before writing a changeset, confirm with the user:
+- which package(s) are affected
+- the bump type (`patch`, `minor`, or `major`)
+- the description
+
+Then create `.changeset/<descriptive-slug>.md`:
+
+```markdown
+---
+"@aligent/<package-name>": patch | minor | major
+---
+
+Short description of the change.
+```
+
+- `patch` — bug fixes, non-breaking tweaks
+- `minor` — new backwards-compatible features
+- `major` — breaking changes

--- a/packages/cdk-aspects/lib/defaults/dynamodb.test.ts
+++ b/packages/cdk-aspects/lib/defaults/dynamodb.test.ts
@@ -22,11 +22,6 @@ describe("DynamoDbDefaultsAspect", () => {
   let app: App;
   let stack: Stack;
 
-  afterEach(() => {
-    app = undefined as unknown as App;
-    stack = undefined as unknown as Stack;
-  });
-
   const setup = (duration: "SHORT" | "MEDIUM" | "LONG") => {
     app = new App();
     stack = new Stack(app, "TestStack");

--- a/packages/cdk-aspects/lib/defaults/dynamodb.test.ts
+++ b/packages/cdk-aspects/lib/defaults/dynamodb.test.ts
@@ -1,0 +1,196 @@
+import { App, Aspects, Stack } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import {
+  AttributeType,
+  BillingMode,
+  CfnTable,
+  Table,
+} from "aws-cdk-lib/aws-dynamodb";
+import { DynamoDbDefaultsAspect } from "./dynamodb";
+
+const makeTable = (
+  stack: Stack,
+  id: string,
+  billingMode?: BillingMode
+): Table =>
+  new Table(stack, id, {
+    partitionKey: { name: "pk", type: AttributeType.STRING },
+    ...(billingMode !== undefined && { billingMode }),
+  });
+
+describe("DynamoDbDefaultsAspect", () => {
+  let app: App;
+  let stack: Stack;
+
+  afterEach(() => {
+    app = undefined as unknown as App;
+    stack = undefined as unknown as Stack;
+  });
+
+  const setup = (duration: "SHORT" | "MEDIUM" | "LONG") => {
+    app = new App();
+    stack = new Stack(app, "TestStack");
+    Aspects.of(stack).add(new DynamoDbDefaultsAspect({ duration }));
+  };
+
+  describe("SHORT duration", () => {
+    beforeEach(() => setup("SHORT"));
+
+    it("sets PROVISIONED billing mode on tables with no explicit billing mode", () => {
+      makeTable(stack, "MyTable");
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+        BillingMode: "PROVISIONED",
+      });
+    });
+
+    it("does not inject ProvisionedThroughput onto a PAY_PER_REQUEST table", () => {
+      makeTable(stack, "OnDemandTable", BillingMode.PAY_PER_REQUEST);
+      app.synth();
+
+      const resources = Template.fromStack(stack).findResources(
+        "AWS::DynamoDB::Table"
+      );
+      const props = Object.values(resources)[0].Properties;
+      expect(props["ProvisionedThroughput"]).toBeUndefined();
+    });
+
+    it("preserves PAY_PER_REQUEST billing mode on an explicit on-demand table", () => {
+      makeTable(stack, "OnDemandTable", BillingMode.PAY_PER_REQUEST);
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+        BillingMode: "PAY_PER_REQUEST",
+      });
+    });
+
+    it("does not override an existing ProvisionedThroughput", () => {
+      const table = makeTable(stack, "MyTable");
+      const cfnTable = table.node.defaultChild as CfnTable;
+      cfnTable.provisionedThroughput = {
+        readCapacityUnits: 10,
+        writeCapacityUnits: 10,
+      };
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+        ProvisionedThroughput: {
+          ReadCapacityUnits: 10,
+          WriteCapacityUnits: 10,
+        },
+      });
+    });
+
+    it("applies DESTROY removal policy", () => {
+      makeTable(stack, "MyTable");
+      app.synth();
+
+      const resources = Template.fromStack(stack).findResources(
+        "AWS::DynamoDB::Table"
+      );
+      expect(Object.values(resources)[0].DeletionPolicy).toBe("Delete");
+    });
+  });
+
+  describe("MEDIUM duration", () => {
+    beforeEach(() => setup("MEDIUM"));
+
+    it("sets PAY_PER_REQUEST billing mode on tables with no explicit billing mode", () => {
+      makeTable(stack, "MyTable");
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+        BillingMode: "PAY_PER_REQUEST",
+      });
+    });
+
+    it("sets on-demand throughput limits on tables with no explicit billing mode", () => {
+      makeTable(stack, "MyTable");
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+        OnDemandThroughput: {
+          MaxReadRequestUnits: 100,
+          MaxWriteRequestUnits: 100,
+        },
+      });
+    });
+
+    it("does not inject OnDemandThroughput when billing mode is forced to PROVISIONED at L1", () => {
+      // CDK L2 omits billingMode for PROVISIONED (it's the CF default), so we force it at L1
+      // to simulate a table where someone has explicitly pinned PROVISIONED via cfnTable override
+      const table = makeTable(stack, "ProvisionedTable");
+      const cfnTable = table.node.defaultChild as CfnTable;
+      cfnTable.billingMode = "PROVISIONED";
+      app.synth();
+
+      const resources = Template.fromStack(stack).findResources(
+        "AWS::DynamoDB::Table"
+      );
+      const props = Object.values(resources)[0].Properties;
+      expect(props["OnDemandThroughput"]).toBeUndefined();
+    });
+
+    it("does not override an existing OnDemandThroughput", () => {
+      const table = makeTable(stack, "MyTable");
+      const cfnTable = table.node.defaultChild as CfnTable;
+      cfnTable.onDemandThroughput = {
+        maxReadRequestUnits: 50,
+        maxWriteRequestUnits: 50,
+      };
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+        OnDemandThroughput: {
+          MaxReadRequestUnits: 50,
+          MaxWriteRequestUnits: 50,
+        },
+      });
+    });
+
+    it("applies DESTROY removal policy", () => {
+      makeTable(stack, "MyTable");
+      app.synth();
+
+      const resources = Template.fromStack(stack).findResources(
+        "AWS::DynamoDB::Table"
+      );
+      expect(Object.values(resources)[0].DeletionPolicy).toBe("Delete");
+    });
+  });
+
+  describe("LONG duration", () => {
+    beforeEach(() => setup("LONG"));
+
+    it("sets PAY_PER_REQUEST billing mode", () => {
+      makeTable(stack, "MyTable");
+      app.synth();
+
+      Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+        BillingMode: "PAY_PER_REQUEST",
+      });
+    });
+
+    it("does not set on-demand throughput limits (no cap for LONG)", () => {
+      makeTable(stack, "MyTable");
+      app.synth();
+
+      const resources = Template.fromStack(stack).findResources(
+        "AWS::DynamoDB::Table"
+      );
+      const props = Object.values(resources)[0].Properties;
+      expect(props["OnDemandThroughput"]).toBeUndefined();
+    });
+
+    it("applies RETAIN removal policy", () => {
+      makeTable(stack, "MyTable");
+      app.synth();
+
+      const resources = Template.fromStack(stack).findResources(
+        "AWS::DynamoDB::Table"
+      );
+      expect(Object.values(resources)[0].DeletionPolicy).toBe("Retain");
+    });
+  });
+});

--- a/packages/cdk-aspects/lib/defaults/dynamodb.ts
+++ b/packages/cdk-aspects/lib/defaults/dynamodb.ts
@@ -128,7 +128,7 @@ export class DynamoDbDefaultsAspect implements IAspect {
 
       if (
         cfnTable.provisionedThroughput === undefined &&
-        cfnTable.billingMode !== "PAY_PER_REQUEST" &&
+        cfnTable.billingMode !== BillingMode.PAY_PER_REQUEST &&
         this.isProvisionedThroughputConfigured()
       ) {
         cfnTable.provisionedThroughput = {
@@ -139,7 +139,7 @@ export class DynamoDbDefaultsAspect implements IAspect {
 
       if (
         cfnTable.onDemandThroughput === undefined &&
-        cfnTable.billingMode !== "PROVISIONED" &&
+        cfnTable.billingMode !== BillingMode.PROVISIONED &&
         this.isOnDemandThroughputConfigured()
       ) {
         cfnTable.onDemandThroughput = {

--- a/packages/cdk-aspects/lib/defaults/dynamodb.ts
+++ b/packages/cdk-aspects/lib/defaults/dynamodb.ts
@@ -128,6 +128,7 @@ export class DynamoDbDefaultsAspect implements IAspect {
 
       if (
         cfnTable.provisionedThroughput === undefined &&
+        cfnTable.billingMode !== "PAY_PER_REQUEST" &&
         this.isProvisionedThroughputConfigured()
       ) {
         cfnTable.provisionedThroughput = {
@@ -138,6 +139,7 @@ export class DynamoDbDefaultsAspect implements IAspect {
 
       if (
         cfnTable.onDemandThroughput === undefined &&
+        cfnTable.billingMode !== "PROVISIONED" &&
         this.isOnDemandThroughputConfigured()
       ) {
         cfnTable.onDemandThroughput = {


### PR DESCRIPTION
## Summary

- `DynamoDbDefaultsAspect` was injecting `ProvisionedThroughput` onto tables that had `BillingMode: PAY_PER_REQUEST` set at the L2 level, producing an invalid CloudFormation template that AWS rejects
- Added a billing-mode guard to both the `provisionedThroughput` injection (Guard 2) and the symmetric `onDemandThroughput` injection (Guard 3), so neither fires when the resolved billing mode is incompatible
- Added a full test suite for `DynamoDbDefaultsAspect` covering all three durations and the regression cases

## Root cause

The two throughput guards checked only whether the property was already set, but not whether the billing mode was compatible:

```typescript
// Before — no billing mode check
if (cfnTable.provisionedThroughput === undefined && this.isProvisionedThroughputConfigured()) { ... }
if (cfnTable.onDemandThroughput === undefined && this.isOnDemandThroughputConfigured()) { ... }
```

Because CDK does not set `cfnTable.provisionedThroughput` for PAY_PER_REQUEST tables, Guard 2 would inject it on any SHORT-stage table that had been explicitly declared on-demand.

## Notes

- A workaround using `addDeletionOverride('Properties.ProvisionedThroughput')` exists in a downstream service repo — that can now be removed
- During investigation, a separate pre-existing issue was found: Guard 2 can never set throughput to `1/1` for SHORT because CDK always initialises `provisionedThroughput: {5, 5}` during L2 construction. That is out of scope for this PR.