### PR TITLE
DO-1765: skip PR workflows on docs-only changes

### DIFF
--- a/.github/workflows/bot-changeset.yml
+++ b/.github/workflows/bot-changeset.yml
@@ -8,6 +8,8 @@ on:
       - '**/docs/**'
       - 'LICENSE'
       - '.github/CODEOWNERS'
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
 
 permissions:
   contents: write

--- a/.github/workflows/bot-changeset.yml
+++ b/.github/workflows/bot-changeset.yml
@@ -11,6 +11,10 @@ on:
       - '.github/workflows/**'
       - '.github/dependabot.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: read

--- a/.github/workflows/bot-changeset.yml
+++ b/.github/workflows/bot-changeset.yml
@@ -3,6 +3,11 @@ name: 🤖 Bot Changeset
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - '**/*.md'
+      - '**/docs/**'
+      - 'LICENSE'
+      - '.github/CODEOWNERS'
 
 permissions:
   contents: write

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -3,6 +3,11 @@ name: Changeset Check
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**/*.md'
+      - '**/docs/**'
+      - 'LICENSE'
+      - '.github/CODEOWNERS'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -8,6 +8,8 @@ on:
       - '**/docs/**'
       - 'LICENSE'
       - '.github/CODEOWNERS'
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/check-readme.yml
+++ b/.github/workflows/check-readme.yml
@@ -6,6 +6,10 @@ on:
       - 'packages/constructs/**'
       - 'README.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-readme:
     name: 📖 Check readme for updates

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,11 @@ name: Pull Request
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/docs/**'
+      - 'LICENSE'
+      - '.github/CODEOWNERS'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,6 +9,7 @@ on:
       - '.github/CODEOWNERS'
       - '.github/workflows/**'
       - '!.github/workflows/pull-request.yml'
+      - '.github/dependabot.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,10 @@ on:
       - '.github/dependabot.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   install:
     name: 📦 Install dependencies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,6 +7,8 @@ on:
       - '**/docs/**'
       - 'LICENSE'
       - '.github/CODEOWNERS'
+      - '.github/workflows/**'
+      - '!.github/workflows/pull-request.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -8,6 +8,10 @@ on:
       - 'packages/**/package.json'
       - 'package.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-lockfile:
     name: 📦 Update yarn.lock


### PR DESCRIPTION
**Description of the proposed changes**

Stops PR-triggered workflows from running on changes that can't affect their outcome, and cancels in-flight runs when a PR is pushed to.

`paths-ignore` added to `pull-request.yml`, `changeset-check.yml`, and `bot-changeset.yml`:
- `**/*.md`, `**/docs/**`, `LICENSE`, `.github/CODEOWNERS`
- `.github/workflows/**` (in `pull-request.yml`, with `!.github/workflows/pull-request.yml` so edits to the pipeline still exercise it)
- `.github/dependabot.yml`

Concurrency (`cancel-in-progress: true`, grouped per PR) added to every PR-triggered workflow that didn't already have it: `pull-request.yml`, `bot-changeset.yml`, `check-readme.yml`, `update-lockfile.yml`. `changeset-check.yml` already had one.

**Notes to reviewers**

- CI-config only — no published `@aligent/cdk-*` package is affected, so no changeset.
- `changeset-release.yml` is `push`-triggered and out of scope.

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback