### PR TITLE
fix: skip CDK-managed singletons in MicroserviceChecks

### DIFF
--- a/.changeset/microservice-checks-skip-cdk-managed.md
+++ b/.changeset/microservice-checks-skip-cdk-managed.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-aspects": minor
+---
+
+`MicroserviceChecks` now skips CDK-managed singleton resources (BucketDeployment custom handler, `LogRetention`, `Custom::S3AutoDeleteObjects`, and `cr.Provider` framework lambdas). These nodes have framework-owned runtime config that consumers cannot tune, so surfacing memory size, timeout, tracing, and log retention nags on them is noise. Consumers no longer need bespoke suppression aspects for these resources.

--- a/packages/cdk-aspects/lib/microservice-checks.test.ts
+++ b/packages/cdk-aspects/lib/microservice-checks.test.ts
@@ -2,6 +2,8 @@ import { App, Aspects, Stack } from "aws-cdk-lib";
 import { Annotations, Match } from "aws-cdk-lib/assertions";
 import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { MicroserviceChecks } from "./microservice-checks";
 
 describe("MicroserviceChecks", () => {
@@ -88,6 +90,64 @@ describe("MicroserviceChecks", () => {
       annotations.hasError(
         "/TestStack/TestLogGroup/Resource",
         Match.stringLikeRegexp("does not have an explicit retention policy")
+      );
+    });
+  });
+
+  describe("CDK-managed singletons", () => {
+    let annotations: Annotations;
+    let bucketDeploymentPath: string;
+
+    beforeAll(() => {
+      const app = new App({
+        context: {
+          "aws:cdk:bundling-stacks": [],
+        },
+      });
+      const stack = new Stack(app, "TestStack");
+      Aspects.of(stack).add(new MicroserviceChecks());
+
+      const bucket = new Bucket(stack, "DeployBucket");
+      new BucketDeployment(stack, "DeployAssets", {
+        destinationBucket: bucket,
+        sources: [Source.data("hello.txt", "hello world")],
+      });
+
+      const singleton = stack.node
+        .findAll()
+        .find(c => c.node.id.startsWith("Custom::CDKBucketDeployment"));
+      if (!singleton) {
+        throw new Error(
+          "BucketDeployment singleton not found — test setup invariant changed"
+        );
+      }
+      bucketDeploymentPath = singleton.node.path;
+
+      annotations = Annotations.fromStack(stack);
+    });
+
+    it("should not nag the BucketDeployment singleton lambda for memory size", () => {
+      annotations.hasNoError(
+        `/${bucketDeploymentPath}/Resource`,
+        Match.stringLikeRegexp(
+          "does not have an explicit memory value configured"
+        )
+      );
+    });
+
+    it("should not nag the BucketDeployment singleton lambda for timeout", () => {
+      annotations.hasNoError(
+        `/${bucketDeploymentPath}/Resource`,
+        Match.stringLikeRegexp(
+          "does not have an explicitly defined timeout value"
+        )
+      );
+    });
+
+    it("should not nag the BucketDeployment singleton lambda for tracing", () => {
+      annotations.hasNoError(
+        `/${bucketDeploymentPath}/Resource`,
+        Match.stringLikeRegexp("does not have tracing set to Tracing.ACTIVE")
       );
     });
   });

--- a/packages/cdk-aspects/lib/microservice-checks.ts
+++ b/packages/cdk-aspects/lib/microservice-checks.ts
@@ -3,6 +3,23 @@ import { NagMessageLevel, NagPack, rules, type NagPackProps } from "cdk-nag";
 import type { IConstruct } from "constructs";
 
 /**
+ * Path fragments identifying CDK-managed singleton resources that consumers
+ * cannot configure. These nodes are skipped during rule evaluation because
+ * surfacing nags on memory size, timeout, tracing, or log retention for
+ * resources owned by the CDK framework is noise.
+ */
+const CDK_MANAGED_PATH_FRAGMENTS = [
+  // aws-s3-deployment.BucketDeployment custom resource handler
+  "Custom::CDKBucketDeployment",
+  // Deprecated CDK log retention custom resource
+  "LogRetention",
+  // Bucket(autoDeleteObjects: true)
+  "Custom::S3AutoDeleteObjects",
+  // cr.Provider framework on-event / is-complete handler
+  "AWS679f53fac002430cb0da5b7982bd2287",
+];
+
+/**
  * Microservice Checks are a compilation of rules to validate infrastructure-as-code template
  * against recommended practices using the cdk-nag library.
  *
@@ -20,6 +37,8 @@ export class MicroserviceChecks extends NagPack {
   }
 
   public visit(node: IConstruct) {
+    if (this.isCdkManagedSingleton(node)) return;
+
     if (node instanceof CfnResource) {
       this.applyRule({
         info: "The Lambda function does not have an explicit memory value configured.",
@@ -54,5 +73,10 @@ export class MicroserviceChecks extends NagPack {
         node: node,
       });
     }
+  }
+
+  private isCdkManagedSingleton(node: IConstruct): boolean {
+    const path = node.node.path;
+    return CDK_MANAGED_PATH_FRAGMENTS.some(fragment => path.includes(fragment));
   }
 }


### PR DESCRIPTION
## Summary
- `MicroserviceChecks` now short-circuits on construct paths owned by the CDK framework so memory size, timeout, tracing, and log retention nags no longer fire on resources consumers cannot configure.
- Covered path fragments: `Custom::CDKBucketDeployment` (aws-s3-deployment), `LogRetention`, `Custom::S3AutoDeleteObjects`, and the `cr.Provider` framework handler (`AWS679f53fac002430cb0da5b7982bd2287`).
- Consumers can retire bespoke `BucketDeploymentNagSuppressionAspect`-style workarounds.

## Why
Surfacing nags on framework-owned singletons is noise — there is no user-tunable knob behind them. Filtering at the pack source avoids polluting the synth output with suppression annotations.

## Changeset
`minor` bump on `@aligent/cdk-aspects` (rule output changes; defensible as `patch` since the prior nags were false positives — happy to downgrade if preferred).

## Test plan
- [x] `yarn nx test cdk-aspects` — 11/11 pass, including a new `CDK-managed singletons` block that synthesises a `BucketDeployment` and asserts `hasNoError` for memory/timeout/tracing on its singleton lambda.
- [x] `yarn nx lint cdk-aspects` — clean (pre-existing warnings in `dynamodb.ts` only).
- [x] Sanity check in a downstream consumer that previously needed a manual suppression aspect.