### PR TITLE
fix: skip AWS-reserved log group names in ResourcePrefixAspect

### DIFF
--- a/.changeset/hot-dodos-give.md
+++ b/.changeset/hot-dodos-give.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-aspects": patch
+---
+
+Skip prefixing AWS-reserved log group names (e.g. `/aws/lambda/...`, `/aws/apigateway/...`). Previously, the `ResourcePrefixAspect` would incorrectly rename these log groups, causing deployment failures since AWS reserves the `/aws/` prefix for its own services. Also fixed base name resolution to check both PascalCase and camelCase CFN property keys.

--- a/packages/cdk-aspects/lib/resource-prefix.test.ts
+++ b/packages/cdk-aspects/lib/resource-prefix.test.ts
@@ -1,14 +1,15 @@
-import { createHash } from "crypto";
 import { App, Aspects, Stack } from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
+import { CfnApplication } from "aws-cdk-lib/aws-appconfig";
 import { AttributeType, Table } from "aws-cdk-lib/aws-dynamodb";
 import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { CfnFunction } from "aws-cdk-lib/aws-lambda";
+import { CfnLogGroup, LogGroup } from "aws-cdk-lib/aws-logs";
 import { CfnBucket } from "aws-cdk-lib/aws-s3";
 import { CfnTopic } from "aws-cdk-lib/aws-sns";
 import { CfnQueue } from "aws-cdk-lib/aws-sqs";
-import { CfnApplication } from "aws-cdk-lib/aws-appconfig";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
+import { createHash } from "crypto";
 import { ResourcePrefixAspect } from "./resource-prefix";
 
 describe("ResourcePrefixAspect", () => {
@@ -174,6 +175,41 @@ describe("ResourcePrefixAspect", () => {
       const functionName = Object.values(resources)[0].Properties
         .FunctionName as string;
       expect(functionName).toBe("myapp-OrdersProcessingFunction");
+    });
+  });
+
+  describe("skip rules", () => {
+    it("should skip log groups with AWS-managed /aws/ prefix", () => {
+      new LogGroup(stack, "LambdaLogGroup", {
+        logGroupName: "/aws/lambda/my-function",
+      });
+
+      app.synth();
+      const template = Template.fromStack(stack);
+      const resources = template.findResources("AWS::Logs::LogGroup");
+      const logGroupName = Object.values(resources)[0].Properties
+        .LogGroupName as string;
+      expect(logGroupName).toBe("/aws/lambda/my-function");
+    });
+
+    it("should prefix log groups with custom names", () => {
+      new LogGroup(stack, "AppLogGroup", { logGroupName: "my-app-logs" });
+
+      app.synth();
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::Logs::LogGroup", {
+        LogGroupName: "myapp-my-app-logs",
+      });
+    });
+
+    it("should prefix log groups without an explicit name", () => {
+      new CfnLogGroup(stack, "DefaultLogGroup", {});
+
+      app.synth();
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::Logs::LogGroup", {
+        LogGroupName: Match.stringLikeRegexp("^myapp-"),
+      });
     });
   });
 

--- a/packages/cdk-aspects/lib/resource-prefix.ts
+++ b/packages/cdk-aspects/lib/resource-prefix.ts
@@ -1,6 +1,6 @@
-import { createHash } from "crypto";
 import { Annotations, CfnResource, IAspect, Stack } from "aws-cdk-lib";
 import { IConstruct } from "constructs";
+import { createHash } from "crypto";
 
 interface ResourceNameConfig {
   /** The CloudFormation property that holds the resource's physical name */
@@ -164,12 +164,11 @@ export class ResourcePrefixAspect implements IAspect {
       (node as CfnResourceWithProps).cfnProperties ??
       {};
 
-    // Get any explicitly set name, or derive one from the logical ID
-    const existingName =
-      typeof cfnProperties[cfnName] === "string"
-        ? cfnProperties[cfnName]
-        : undefined;
-    const baseName = existingName ?? this.deriveNameFromLogicalId(node);
+    const baseName = this.resolveBaseName(node, cfnName, cfnProperties);
+
+    if (this.shouldSkipResource(resourceType, baseName)) {
+      return;
+    }
 
     if (this.isAlreadyPrefixed(baseName)) {
       return;
@@ -192,13 +191,38 @@ export class ResourcePrefixAspect implements IAspect {
     node.addPropertyOverride(cfnName, finalName);
   }
 
-  private isAlreadyPrefixed(name: string): boolean {
+  /**
+   * Determines whether a resource should be skipped from prefixing based on
+   * resource-type-specific rules (e.g., AWS-reserved naming conventions).
+   */
+  private shouldSkipResource(cfnResourceType: string, baseName: string) {
+    return (
+      cfnResourceType === "AWS::Logs::LogGroup" && baseName.startsWith("/aws/")
+    );
+  }
+
+  private isAlreadyPrefixed(name: string) {
     return (
       name.startsWith(`${this.prefix}-`) || name.startsWith(`/${this.prefix}/`)
     );
   }
 
-  private deriveNameFromLogicalId(node: CfnResource) {
+  /**
+   * Resolves the base name for a resource by checking explicitly set CFN properties
+   * first, then falling back to deriving a name from the logical ID.
+   * CDK stores L1 properties in camelCase internally, so both casings are checked.
+   */
+  private resolveBaseName(
+    node: CfnResource,
+    cfnName: string,
+    cfnProperties: Record<string, unknown>
+  ) {
+    const camelCfnName = cfnName.charAt(0).toLowerCase() + cfnName.slice(1);
+    const rawName = cfnProperties[cfnName] ?? cfnProperties[camelCfnName];
+    if (typeof rawName === "string") {
+      return rawName;
+    }
+
     const logicalId = Stack.of(node).getLogicalId(node);
     return logicalId
       .replace(/[^a-zA-Z0-9]+/g, "-") // non-alphanumeric → dash
@@ -217,7 +241,7 @@ export class ResourcePrefixAspect implements IAspect {
     baseName: string,
     cfnResourceType: string,
     cfnProperties: Record<string, unknown>
-  ): string {
+  ) {
     // Special case: FIFO queues must end with .fifo suffix
     if (
       cfnResourceType === "AWS::SQS::Queue" &&


### PR DESCRIPTION
**Description of the proposed changes**

- Skip prefixing log groups with AWS-reserved `/aws/` prefix (e.g. `/aws/lambda/...`, `/aws/apigateway/...`) in `ResourcePrefixAspect`, which previously caused deployment failures
- Fixed base name resolution to check both PascalCase and camelCase CFN property keys, since CDK stores L1 properties in camelCase internally

**Notes to reviewers**

- 🛈 Toggl Code: _MI-322: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback