### PR TITLE
fix: publish declarations from @aligent/cdk-secure-rest-api

### DIFF
--- a/.changeset/secure-rest-api-publish-declarations.md
+++ b/.changeset/secure-rest-api-publish-declarations.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-secure-rest-api": patch
+---
+
+Fix published artifact: declarations (`*.d.ts`) were missing from the tarball because the package had no `.npmignore`, so `npm pack` fell back to the workspace `.gitignore` (which excludes build outputs). Consumers with `isolatedModules: true` then resolved `index.ts` directly and hit `TS1205` on the type re-exports. This release adds the package's own `.npmignore` (matching sibling packages) and converts the type re-exports in `index.ts` to `export type`.

--- a/packages/constructs/secure-rest-api/.npmignore
+++ b/packages/constructs/secure-rest-api/.npmignore
@@ -1,0 +1,29 @@
+# TypeScript source files
+*.ts
+!*.d.ts
+
+# TypeScript configuration
+tsconfig*.json
+
+# Jest configuration
+jest.config.ts
+
+# Nx project configuration
+project.json
+
+# Test files
+test/
+**/*.test.ts
+**/*.test.js
+**/*.spec.ts
+**/*.spec.js
+
+# Development dependencies
+node_modules/
+
+# Keep these files in published package:
+# *.js (compiled JavaScript)
+# *.d.ts (TypeScript declarations)
+# README.md
+# CHANGELOG.md
+# package.json

--- a/packages/constructs/secure-rest-api/index.ts
+++ b/packages/constructs/secure-rest-api/index.ts
@@ -4,4 +4,5 @@ import {
   SecureRestApiRoute,
 } from "./lib/secure-rest-api";
 
-export { SecureRestApi, SecureRestApiProps, SecureRestApiRoute };
+export { SecureRestApi };
+export type { SecureRestApiProps, SecureRestApiRoute };


### PR DESCRIPTION
## Summary

- `@aligent/cdk-secure-rest-api@1.1.0` shipped without `.d.ts` files because the package had no `.npmignore`, so `npm pack` fell back to the workspace `.gitignore` (which excludes build outputs).
- Consumers with `isolatedModules: true` resolved `index.ts` directly and hit `TS1205` on the type re-exports.
- TS-aware loaders like `tsx` additionally preferred the shipped `.ts` source over `index.js`, causing `SecureRestApi is not a constructor` at runtime in ESM consumers.

### Changes

- Add `packages/constructs/secure-rest-api/.npmignore` matching sibling packages — excludes `*.ts` source / tests / configs while preserving `*.d.ts` declarations.
- Split `index.ts` into a value re-export (`SecureRestApi`) and `export type` re-export (`SecureRestApiProps`, `SecureRestApiRoute`) — defends against any future scenario where consumers resolve the source again.
- Add a `patch` changeset.

Verified locally with `npm pack --dry-run`: tarball is now 7 files (down from 13), no `.ts` source, includes both `index.d.ts` and `lib/secure-rest-api.d.ts`.

## Test plan

- [x] `yarn nx lint secure-rest-api` passes
- [x] `yarn nx build secure-rest-api` produces `index.d.ts` + `lib/secure-rest-api.d.ts`
- [x] `yarn nx test secure-rest-api` passes (12/12)
- [x] `npm pack --dry-run` lists `*.d.ts` and excludes `*.ts` source, test, and config files
- [ ] After publish to `1.1.1`, consumer-side `.yarn/patch` for this package can be removed

## Follow-ups (not in this PR)

- `prerender-fargate` is missing `.npmignore` for the same reason — likely has the same bug in its published tarball.
- Type re-export hygiene (`export type`) is missing across most packages — currently masked by `.d.ts` shipping correctly, but worth a sweep.
- Consider a CI guard (`npm pack --dry-run | grep -q '\.d\.ts'`) to catch this class of regression before publish.