### PR TITLE
fix(cdk-aspects): declare aws-cdk-lib and constructs as peerDependencies

### DIFF
--- a/.changeset/cdk-aspects-peer-dependencies.md
+++ b/.changeset/cdk-aspects-peer-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@aligent/cdk-aspects": patch
+---
+
+Move `aws-cdk-lib` and `constructs` from `dependencies` to `peerDependencies`, matching the convention used by every `@aligent/cdk-*` construct package.
+
+As regular dependencies, a consumer whose own `aws-cdk-lib` resolved to a different version ended up with two copies in the tree. The aspects' `instanceof CfnResource` checks compared against the nested copy's class, so `visit()` returned early for every node — aspects silently became a no-op (no prefixes, no defaults, no checks) with a valid-but-untouched synth. Declaring them as peers guarantees a single shared instance with the consumer.

--- a/packages/cdk-aspects/package.json
+++ b/packages/cdk-aspects/package.json
@@ -28,9 +28,11 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.257.0",
-    "constructs": "^10.5.0",
     "esbuild": "^0.28.0",
     "source-map-support": "^0.5.21"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.113.0",
+    "constructs": "^10.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,14 +12,15 @@ __metadata:
     "@types/jest": "npm:^29.5.10"
     "@types/node": "npm:^24.12.4"
     aws-cdk: "npm:^2.1124.1"
-    aws-cdk-lib: "npm:^2.257.0"
-    constructs: "npm:^10.5.0"
     esbuild: "npm:^0.28.0"
     jest: "npm:^29.7.0"
     source-map-support: "npm:^0.5.21"
     ts-jest: "npm:^29.4.9"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.3.2"
+  peerDependencies:
+    aws-cdk-lib: ^2.113.0
+    constructs: ^10.5.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Moves `aws-cdk-lib` and `constructs` from `dependencies` to `peerDependencies` in `@aligent/cdk-aspects`, matching the convention used by every other `@aligent/cdk-*` construct package.

## Why

As regular `dependencies`, a consumer whose own `aws-cdk-lib` resolves to a different version ends up with **two copies** in the tree — the app's, and a nested one under `@aligent/cdk-aspects`. The aspects' `node instanceof CfnResource` guard compares against the *nested* copy's class, while the constructs being visited are instances of the *app's* copy. Different class objects → `instanceof` is always `false` → `visit()` returns early for every node.

Result: aspects silently become a **no-op** — no prefixes, no defaults, no checks — with a valid-but-untouched synth and no error or warning. Declaring them as peers guarantees a single shared instance with the consumer.

## Changes

- `packages/cdk-aspects/package.json` — `aws-cdk-lib` (`^2.113.0`) and `constructs` (`^10.5.0`) moved to `peerDependencies`. Range widened from the old `^2.257.0` pin to the repo's dominant peer range; a peer should accept a broad span of consumer CDK versions, and the aspects only touch the stable `CfnResource` API.
- `yarn.lock` — reflects the move; no duplicate `aws-cdk-lib` locator introduced.
- `.changeset/` — `patch` bump.

## Verification

- `yarn nx build/test/lint cdk-aspects` — all pass (55 tests green).
- `yarn changeset:status` — single patch bump for `@aligent/cdk-aspects`.
- Lockfile inspected: one `aws-cdk-lib` locator, no nested duplicate.

## Notes

Scoped to the peer-dependency packaging fix only. The separate `ResourcePrefixAspect` token/empty-base-name regression reported alongside this is already fixed on `main` by MI-323 (0.6.3) and is **not** part of this PR.