### PR TITLE
fix: skip CDK-managed singletons in ResourcePrefixAspect

### DIFF
--- a/.changeset/resource-prefix-skip-cdk-managed-singletons.md
+++ b/.changeset/resource-prefix-skip-cdk-managed-singletons.md
@@ -2,4 +2,11 @@
 "@aligent/cdk-aspects": patch
 ---
 
-Fix `ResourcePrefixAspect` to skip CDK-managed singleton/framework resources (`BucketDeployment` handler, `LogRetention`, `S3AutoDeleteObjects`, and `cr.Provider` framework lambdas) instead of pinning deterministic physical names onto them. Pinning a deterministic name removed CloudFormation's random-suffix orphan-avoidance, so a failed deploy could orphan the service-created `/aws/lambda/<fn>` log group and wedge every subsequent deploy on `AWS::Logs::LogGroup ... already exists`. The aspect now leaves these resources CloudFormation-named, matching the singleton-skip behaviour `MicroserviceChecks` already applies.
+Fix `ResourcePrefixAspect` to skip CDK-managed singleton/framework resources (`BucketDeployment` handler, `LogRetention`, `S3AutoDeleteObjects`, and `cr.Provider` framework lambdas) and their nested children (IAM service roles, log groups) instead of pinning deterministic physical names onto them.
+
+These singletons share a fixed logical id across every stack, so a deterministic prefixed name collapses to one value per prefix scope. That removed CloudFormation's per-stack and per-creation uniqueness and caused two deploy failures:
+
+- **Cross-stack IAM role collision** — two `BucketDeployment`-using stacks in the same stage received the same account-global `RoleName`, so the second stack failed with `... already exists`.
+- **Orphaned `/aws/lambda` log group collision on retry** — a failed deploy orphaned the service-created log group, and the deterministic function name regenerated the identical name, wedging every subsequent deploy on `AWS::Logs::LogGroup ... already exists`.
+
+The aspect now leaves these resources CloudFormation-named, matching the singleton-skip behaviour `MicroserviceChecks` already applies.

--- a/.changeset/resource-prefix-skip-cdk-managed-singletons.md
+++ b/.changeset/resource-prefix-skip-cdk-managed-singletons.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-aspects": patch
+---
+
+Fix `ResourcePrefixAspect` to skip CDK-managed singleton/framework resources (`BucketDeployment` handler, `LogRetention`, `S3AutoDeleteObjects`, and `cr.Provider` framework lambdas) instead of pinning deterministic physical names onto them. Pinning a deterministic name removed CloudFormation's random-suffix orphan-avoidance, so a failed deploy could orphan the service-created `/aws/lambda/<fn>` log group and wedge every subsequent deploy on `AWS::Logs::LogGroup ... already exists`. The aspect now leaves these resources CloudFormation-named, matching the singleton-skip behaviour `MicroserviceChecks` already applies.

--- a/packages/cdk-aspects/README.md
+++ b/packages/cdk-aspects/README.md
@@ -116,7 +116,7 @@ Automatically prefixes physical resource names across supported AWS resource typ
 - **Automatic truncation**: if a prefixed name would exceed AWS's maximum length for that resource type, the aspect truncates the name and appends an 8-character SHA-256 hash to maintain uniqueness. A CDK warning is emitted for each truncated resource. This prevents L3 constructs (e.g. `BucketDeployment`) from generating child resources that cause synthesis failures.
 - Idempotent: already-prefixed resources are skipped
 - Skips AWS-reserved log group names (e.g. `/aws/lambda/...`)
-- Skips CDK-managed singleton/framework resources (`BucketDeployment` handler, `LogRetention`, `S3AutoDeleteObjects`, and `cr.Provider` framework lambdas). Their physical names are left CloudFormation-generated so a failed deploy's orphaned `/aws/lambda` log group never collides with a deterministic name on retry.
+- Skips CDK-managed singleton/framework resources (`BucketDeployment` handler, `LogRetention`, `S3AutoDeleteObjects`, and `cr.Provider` framework lambdas) and their nested children (IAM service roles, log groups). These singletons share a fixed logical id across every stack, so a deterministic prefixed name collapses to one value per prefix scope. Leaving them CloudFormation-generated preserves the per-stack and per-creation uniqueness that prevents account-global IAM role collisions across stacks and orphaned `/aws/lambda` log group collisions on retry.
 - Supports an exclusion list to skip specific resource types
 
 ### Usage

--- a/packages/cdk-aspects/README.md
+++ b/packages/cdk-aspects/README.md
@@ -115,6 +115,8 @@ Automatically prefixes physical resource names across supported AWS resource typ
 - Handles resource-specific naming rules: S3 names are lowercased, FIFO queues/topics preserve the `.fifo` suffix, SSM parameters use path-style prefixes (`/prefix/name`)
 - **Automatic truncation**: if a prefixed name would exceed AWS's maximum length for that resource type, the aspect truncates the name and appends an 8-character SHA-256 hash to maintain uniqueness. A CDK warning is emitted for each truncated resource. This prevents L3 constructs (e.g. `BucketDeployment`) from generating child resources that cause synthesis failures.
 - Idempotent: already-prefixed resources are skipped
+- Skips AWS-reserved log group names (e.g. `/aws/lambda/...`)
+- Skips CDK-managed singleton/framework resources (`BucketDeployment` handler, `LogRetention`, `S3AutoDeleteObjects`, and `cr.Provider` framework lambdas). Their physical names are left CloudFormation-generated so a failed deploy's orphaned `/aws/lambda` log group never collides with a deterministic name on retry.
 - Supports an exclusion list to skip specific resource types
 
 ### Usage

--- a/packages/cdk-aspects/lib/cdk-managed-singletons.ts
+++ b/packages/cdk-aspects/lib/cdk-managed-singletons.ts
@@ -1,0 +1,30 @@
+import type { IConstruct } from "constructs";
+
+/**
+ * Path fragments identifying CDK-managed singleton/framework resources that
+ * consumers cannot configure or own.
+ *
+ * Aspects should leave these resources untouched: their runtime config is
+ * framework-owned (so cdk-nag rules are noise), and their physical names must
+ * stay CloudFormation-generated (so a failed deploy's orphaned `/aws/lambda`
+ * LogGroup never collides with a deterministic name on the next attempt).
+ */
+export const CDK_MANAGED_PATH_FRAGMENTS = [
+  // aws-s3-deployment.BucketDeployment custom resource handler
+  "Custom::CDKBucketDeployment",
+  // Deprecated CDK log retention custom resource
+  "LogRetention",
+  // Bucket(autoDeleteObjects: true)
+  "Custom::S3AutoDeleteObjects",
+  // cr.Provider framework on-event / is-complete handler
+  "AWS679f53fac002430cb0da5b7982bd2287",
+];
+
+/**
+ * Returns true when the construct lives under a CDK-managed singleton/framework
+ * path and should therefore be skipped by aspects.
+ */
+export function isCdkManagedSingleton(node: IConstruct): boolean {
+  const path = node.node.path;
+  return CDK_MANAGED_PATH_FRAGMENTS.some(fragment => path.includes(fragment));
+}

--- a/packages/cdk-aspects/lib/microservice-checks.ts
+++ b/packages/cdk-aspects/lib/microservice-checks.ts
@@ -1,23 +1,7 @@
 import { CfnResource } from "aws-cdk-lib";
 import { NagMessageLevel, NagPack, rules, type NagPackProps } from "cdk-nag";
 import type { IConstruct } from "constructs";
-
-/**
- * Path fragments identifying CDK-managed singleton resources that consumers
- * cannot configure. These nodes are skipped during rule evaluation because
- * surfacing nags on memory size, timeout, tracing, or log retention for
- * resources owned by the CDK framework is noise.
- */
-const CDK_MANAGED_PATH_FRAGMENTS = [
-  // aws-s3-deployment.BucketDeployment custom resource handler
-  "Custom::CDKBucketDeployment",
-  // Deprecated CDK log retention custom resource
-  "LogRetention",
-  // Bucket(autoDeleteObjects: true)
-  "Custom::S3AutoDeleteObjects",
-  // cr.Provider framework on-event / is-complete handler
-  "AWS679f53fac002430cb0da5b7982bd2287",
-];
+import { isCdkManagedSingleton } from "./cdk-managed-singletons";
 
 /**
  * Microservice Checks are a compilation of rules to validate infrastructure-as-code template
@@ -37,7 +21,7 @@ export class MicroserviceChecks extends NagPack {
   }
 
   public visit(node: IConstruct) {
-    if (this.isCdkManagedSingleton(node)) return;
+    if (isCdkManagedSingleton(node)) return;
 
     if (node instanceof CfnResource) {
       this.applyRule({
@@ -73,10 +57,5 @@ export class MicroserviceChecks extends NagPack {
         node: node,
       });
     }
-  }
-
-  private isCdkManagedSingleton(node: IConstruct): boolean {
-    const path = node.node.path;
-    return CDK_MANAGED_PATH_FRAGMENTS.some(fragment => path.includes(fragment));
   }
 }

--- a/packages/cdk-aspects/lib/resource-prefix.test.ts
+++ b/packages/cdk-aspects/lib/resource-prefix.test.ts
@@ -1,11 +1,20 @@
-import { App, Aspects, Fn, Lazy, Stack } from "aws-cdk-lib";
+import {
+  App,
+  Aspects,
+  CfnResource,
+  Fn,
+  Lazy,
+  RemovalPolicy,
+  Stack,
+} from "aws-cdk-lib";
 import { Annotations, Match, Template } from "aws-cdk-lib/assertions";
 import { CfnApplication } from "aws-cdk-lib/aws-appconfig";
 import { AttributeType, Table } from "aws-cdk-lib/aws-dynamodb";
 import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { CfnFunction } from "aws-cdk-lib/aws-lambda";
 import { CfnLogGroup, LogGroup } from "aws-cdk-lib/aws-logs";
-import { CfnBucket } from "aws-cdk-lib/aws-s3";
+import { Bucket, CfnBucket } from "aws-cdk-lib/aws-s3";
+import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { CfnTopic } from "aws-cdk-lib/aws-sns";
 import { CfnQueue } from "aws-cdk-lib/aws-sqs";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
@@ -210,6 +219,83 @@ describe("ResourcePrefixAspect", () => {
       template.hasResourceProperties("AWS::Logs::LogGroup", {
         LogGroupName: Match.stringLikeRegexp("^myapp-"),
       });
+    });
+  });
+
+  describe("CDK-managed singletons", () => {
+    // BucketDeployment provisions a framework-owned singleton handler Lambda whose
+    // physical name the consumer cannot tune. Pinning a deterministic name onto it
+    // breaks CloudFormation's random-suffix orphan-avoidance for the /aws/lambda
+    // LogGroup the Lambda service auto-creates.
+    const synthWithBucketDeployment = () => {
+      const bundlingApp = new App({
+        context: { "aws:cdk:bundling-stacks": [] },
+      });
+      const bundlingStack = new Stack(bundlingApp, "TestStack");
+      Aspects.of(bundlingStack).add(
+        new ResourcePrefixAspect({ prefix: "myapp" })
+      );
+
+      const bucket = new Bucket(bundlingStack, "DeployBucket");
+      new BucketDeployment(bundlingStack, "DeployAssets", {
+        destinationBucket: bucket,
+        sources: [Source.data("hello.txt", "hello world")],
+      });
+
+      bundlingApp.synth();
+      return bundlingStack;
+    };
+
+    const findSingletonHandler = (stackToSearch: Stack) => {
+      const handler = stackToSearch.node
+        .findAll()
+        .find(
+          c =>
+            c instanceof CfnFunction &&
+            c.node.path.includes("Custom::CDKBucketDeployment")
+        ) as CfnFunction | undefined;
+      if (!handler) {
+        throw new Error(
+          "BucketDeployment singleton handler not found — test setup invariant changed"
+        );
+      }
+      return handler;
+    };
+
+    it("should not assign an explicit name to the BucketDeployment handler lambda", () => {
+      const synthStack = synthWithBucketDeployment();
+      const handler = findSingletonHandler(synthStack);
+      const logicalId = synthStack.getLogicalId(handler);
+
+      const template = Template.fromStack(synthStack);
+      const resources = template.findResources("AWS::Lambda::Function");
+      expect(resources[logicalId].Properties?.FunctionName).toBeUndefined();
+    });
+
+    it("should not assign an explicit name to the S3AutoDeleteObjects handler lambda", () => {
+      new Bucket(stack, "EphemeralBucket", {
+        autoDeleteObjects: true,
+        removalPolicy: RemovalPolicy.DESTROY,
+      });
+
+      app.synth();
+
+      // The autoDeleteObjects handler is provisioned via CustomResourceProvider
+      // as a raw CfnResource (not a CfnFunction L1 instance).
+      const handler = stack.node
+        .findAll()
+        .find(
+          (c): c is CfnResource =>
+            c instanceof CfnResource &&
+            c.cfnResourceType === "AWS::Lambda::Function" &&
+            c.node.path.includes("Custom::S3AutoDeleteObjects")
+        );
+      expect(handler).toBeDefined();
+      const logicalId = stack.getLogicalId(handler as CfnResource);
+
+      const template = Template.fromStack(stack);
+      const resources = template.findResources("AWS::Lambda::Function");
+      expect(resources[logicalId].Properties?.FunctionName).toBeUndefined();
     });
   });
 

--- a/packages/cdk-aspects/lib/resource-prefix.test.ts
+++ b/packages/cdk-aspects/lib/resource-prefix.test.ts
@@ -272,6 +272,28 @@ describe("ResourcePrefixAspect", () => {
       expect(resources[logicalId].Properties?.FunctionName).toBeUndefined();
     });
 
+    it("should not assign an explicit name to the BucketDeployment handler service role", () => {
+      // The singleton handler's IAM role is nested under the same path. A
+      // deterministic, logical-id-derived RoleName is identical across every
+      // stack in a prefix scope, and IAM role names are account-global — so two
+      // BucketDeployment-using stacks in the same stage collide on it.
+      const synthStack = synthWithBucketDeployment();
+      const role = synthStack.node
+        .findAll()
+        .find(
+          (c): c is CfnResource =>
+            c instanceof CfnResource &&
+            c.cfnResourceType === "AWS::IAM::Role" &&
+            c.node.path.includes("Custom::CDKBucketDeployment")
+        );
+      expect(role).toBeDefined();
+      const logicalId = synthStack.getLogicalId(role as CfnResource);
+
+      const template = Template.fromStack(synthStack);
+      const resources = template.findResources("AWS::IAM::Role");
+      expect(resources[logicalId].Properties?.RoleName).toBeUndefined();
+    });
+
     it("should not assign an explicit name to the S3AutoDeleteObjects handler lambda", () => {
       new Bucket(stack, "EphemeralBucket", {
         autoDeleteObjects: true,

--- a/packages/cdk-aspects/lib/resource-prefix.ts
+++ b/packages/cdk-aspects/lib/resource-prefix.ts
@@ -1,6 +1,7 @@
 import { Annotations, CfnResource, IAspect, Stack, Token } from "aws-cdk-lib";
 import { IConstruct } from "constructs";
 import { createHash } from "crypto";
+import { isCdkManagedSingleton } from "./cdk-managed-singletons";
 
 interface ResourceNameConfig {
   /** The CloudFormation property that holds the resource's physical name */
@@ -155,6 +156,13 @@ export class ResourcePrefixAspect implements IAspect {
 
   visit(node: IConstruct) {
     if (!(node instanceof CfnResource)) return;
+
+    // CDK-managed singleton/framework resources must keep their
+    // CloudFormation-generated physical names. Pinning a deterministic name onto
+    // them (e.g. the BucketDeployment handler) removes the random-suffix
+    // orphan-avoidance and wedges deploys on `/aws/lambda/<fn>` LogGroup
+    // "already exists" after any failed attempt.
+    if (isCdkManagedSingleton(node)) return;
 
     const resourceType = node.cfnResourceType;
     const config = RESOURCE_CONFIG[resourceType];


### PR DESCRIPTION
## Summary

`ResourcePrefixAspect` assigned deterministic, logical-id-derived physical names to CDK-managed singleton/framework resources — notably the `BucketDeployment` custom-resource handler and its nested IAM service role and log group. Because these singletons share a **fixed logical id across every stack**, the prefixed name collapses to a single value per prefix scope, removing the per-stack and per-creation uniqueness CloudFormation normally provides. This caused two distinct deploy failures.

### Failure mode 1 (severe): cross-stack IAM role collision

Two `BucketDeployment`-using stacks in the same stage/brand received the **same** account-global `RoleName`, so the second stack failed:

```
CREATE_FAILED | AWS::IAM::Role | ...CustomCDKBucketDeployment8693-... already exists
```

Version-independent (the aspect has set explicit `RoleName`/`FunctionName` on these singletons since ≥ 0.5.7).

### Failure mode 2: orphaned `/aws/lambda` LogGroup collision on retry

The handler runs during deploy; the Lambda service auto-creates `/aws/lambda/<fn>`. A failed/rolled-back deploy orphans that group (CFN never owned it, so `cdk destroy` doesn't clear it), and the deterministic function name regenerates the identical name on retry:

```
Resource of type 'AWS::Logs::LogGroup' with identifier
'.../aws/lambda/...-CustomCDKBucketDeployment8693-<hash>' already exists.
```

Surfaced after `0.6.1` (which correctly stopped mangling `/aws/` log group names — that fix exposed the latent collision).

## Fix

- Extract the singleton path-fragment list + `isCdkManagedSingleton` helper into a new internal `lib/cdk-managed-singletons.ts` — single source of truth.
- `MicroserviceChecks` refactored to consume it (behaviour-preserving).
- `ResourcePrefixAspect.visit()` skips these resources, leaving their physical names CloudFormation-generated. The path-`includes` skip covers the handler **and its nested children** (IAM service role, log group), resolving both failure modes at once. Keeps the `0.6.1` `/aws/` log-group fix intact.

Covered singletons: `Custom::CDKBucketDeployment`, `LogRetention`, `Custom::S3AutoDeleteObjects`, `cr.Provider` (`AWS679f53fac002430cb0da5b7982bd2287`).

## Testing

- TDD (red → green). Behaviour tests assert the `BucketDeployment` handler lambda, its IAM **service role**, and the `S3AutoDeleteObjects` handler all keep CloudFormation-generated names.
- Verified against the unfixed aspect that the role/function were previously pinned to `myapp-CustomCDKBucketDeployment8693-...`.
- `build` + `test` (58 passed) + `lint` all green.

## Changeset

`@aligent/cdk-aspects`: **patch**
