### PR TITLE
fix: isolate maintenance handler test filesystem state

### DIFF
--- a/.changeset/isolate-maintenance-test-filesystem-state.md
+++ b/.changeset/isolate-maintenance-test-filesystem-state.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-graphql-mesh-server": patch
+---
+
+Resolve MAINTENANCE_FILE_PATH lazily so the maintenance handler honours the runtime-configured path; fixes flaky maintenance handler tests via per-suite filesystem isolation.

--- a/packages/constructs/graphql-mesh-server/assets/handlers/maintenance/lib/file.test.ts
+++ b/packages/constructs/graphql-mesh-server/assets/handlers/maintenance/lib/file.test.ts
@@ -1,0 +1,27 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getFilePath, getMaintenanceFile, setWhitelist } from "./file";
+
+describe("maintenance file storage", () => {
+  it("resolves the file path under the current MAINTENANCE_FILE_PATH", () => {
+    const dir = mkdtempSync(join(tmpdir(), "maint-"));
+    process.env.MAINTENANCE_FILE_PATH = dir;
+
+    expect(getFilePath().startsWith(dir)).toBe(true);
+  });
+
+  it("keeps state in separate directories isolated from each other", () => {
+    const dirA = mkdtempSync(join(tmpdir(), "maint-a-"));
+    const dirB = mkdtempSync(join(tmpdir(), "maint-b-"));
+
+    process.env.MAINTENANCE_FILE_PATH = dirA;
+    setWhitelist(["10.0.0.1"]);
+
+    process.env.MAINTENANCE_FILE_PATH = dirB;
+    expect(getMaintenanceFile().whitelist).toEqual([]);
+
+    process.env.MAINTENANCE_FILE_PATH = dirA;
+    expect(getMaintenanceFile().whitelist).toEqual(["10.0.0.1"]);
+  });
+});

--- a/packages/constructs/graphql-mesh-server/assets/handlers/maintenance/lib/file.ts
+++ b/packages/constructs/graphql-mesh-server/assets/handlers/maintenance/lib/file.ts
@@ -5,13 +5,19 @@ const IP_REGEX =
 const IP_V6_REGEX =
   /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))/;
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const MAINTENANCE_FILE_PATH = process.env.MAINTENANCE_FILE_PATH!;
 const FILE_NAME = "maintenance";
-const PATHS = [
-  `${MAINTENANCE_FILE_PATH}/${FILE_NAME}.disabled`,
-  `${MAINTENANCE_FILE_PATH}/${FILE_NAME}.enabled`,
-];
+
+// Resolved lazily so each caller honours the current MAINTENANCE_FILE_PATH
+// rather than a value captured at module load.
+const getPaths = (): [string, string] => {
+  const basePath = process.env.MAINTENANCE_FILE_PATH;
+  if (!basePath) throw new Error("Maintenance File path is missing.");
+
+  return [
+    `${basePath}/${FILE_NAME}.disabled`,
+    `${basePath}/${FILE_NAME}.enabled`,
+  ];
+};
 
 export interface MaintenanceFile {
   whitelist: Array<string>;
@@ -19,15 +25,16 @@ export interface MaintenanceFile {
 }
 
 export const getFilePath = (): string => {
-  for (const path of PATHS) {
+  const paths = getPaths();
+  for (const path of paths) {
     if (existsSync(path)) {
       return path;
     }
   }
 
   // If the maintenance file wasn't found, create one
-  writeFileSync(PATHS[0], JSON.stringify({ whitelist: [], sites: {} }));
-  return PATHS[0];
+  writeFileSync(paths[0], JSON.stringify({ whitelist: [], sites: {} }));
+  return paths[0];
 };
 
 export const getMaintenanceFile = (): MaintenanceFile => {
@@ -63,12 +70,10 @@ export const updateMaintenanceStatus = (sites: Record<string, boolean>) => {
 };
 
 export const toggleMaintenanceStatus = (status: boolean) => {
-  const desiredStatus = status ? "enabled" : "disabled";
+  const [disabledPath, enabledPath] = getPaths();
+  const target = status ? enabledPath : disabledPath;
 
-  renameSync(
-    getFilePath(),
-    `${MAINTENANCE_FILE_PATH}/${FILE_NAME}.${desiredStatus}`
-  );
+  renameSync(getFilePath(), target);
 };
 
 const validateIps = (ipList: Array<string>) => {

--- a/packages/constructs/graphql-mesh-server/assets/handlers/maintenance/maintenance.test.ts
+++ b/packages/constructs/graphql-mesh-server/assets/handlers/maintenance/maintenance.test.ts
@@ -1,9 +1,15 @@
 // handler.test.ts
-import { cwd } from "process";
 import { handler } from "./maintenance";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { updateMaintenanceStatus } from "./lib/file";
-import { existsSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Each suite owns an isolated directory so parallel suites can't race on a
+// shared maintenance file (see lib/file.ts MAINTENANCE_FILE_PATH).
+const maintenanceDir = mkdtempSync(join(tmpdir(), "maint-maintenance-"));
+process.env.MAINTENANCE_FILE_PATH = maintenanceDir;
 
 const createMockEvent = (
   method: string,
@@ -28,11 +34,11 @@ const mockSites = { "example.com": false, "example.com.au": false };
 describe("Lambda handler", () => {
   beforeEach(() => {
     // Clean up any existing maintenance files before each test
-    if (existsSync(`${cwd()}/maintenance.enabled`)) {
-      rmSync(`${cwd()}/maintenance.enabled`);
+    if (existsSync(`${maintenanceDir}/maintenance.enabled`)) {
+      rmSync(`${maintenanceDir}/maintenance.enabled`);
     }
-    if (existsSync(`${cwd()}/maintenance.disabled`)) {
-      rmSync(`${cwd()}/maintenance.disabled`);
+    if (existsSync(`${maintenanceDir}/maintenance.disabled`)) {
+      rmSync(`${maintenanceDir}/maintenance.disabled`);
     }
     // Reset the maintenance status before each test to ensure test isolation
     updateMaintenanceStatus(mockSites);
@@ -55,7 +61,7 @@ describe("Lambda handler", () => {
 
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual(mockUpdate);
-    expect(existsSync(`${cwd()}/maintenance.enabled`)).toBe(true);
+    expect(existsSync(`${maintenanceDir}/maintenance.enabled`)).toBe(true);
   });
 
   it("should handle POST'ing a disable all sites", async () => {
@@ -67,7 +73,7 @@ describe("Lambda handler", () => {
     await handler(enableEvent);
 
     // Verify the file is in enabled state as expected
-    expect(existsSync(`${cwd()}/maintenance.enabled`)).toBe(true);
+    expect(existsSync(`${maintenanceDir}/maintenance.enabled`)).toBe(true);
 
     // Now test disabling all sites
     const mockUpdate = {
@@ -78,16 +84,10 @@ describe("Lambda handler", () => {
 
     expect(result.statusCode).toBe(200);
     expect(JSON.parse(result.body)).toEqual(mockUpdate);
-    expect(existsSync(`${cwd()}/maintenance.disabled`)).toBe(true);
+    expect(existsSync(`${maintenanceDir}/maintenance.disabled`)).toBe(true);
   });
 
   afterAll(() => {
-    if (existsSync(`${cwd()}/maintenance.enabled`)) {
-      rmSync(`${cwd()}/maintenance.enabled`);
-    }
-
-    if (existsSync(`${cwd()}/maintenance.disabled`)) {
-      rmSync(`${cwd()}/maintenance.disabled`);
-    }
+    rmSync(maintenanceDir, { recursive: true, force: true });
   });
 });

--- a/packages/constructs/graphql-mesh-server/assets/handlers/maintenance/whitelist.test.ts
+++ b/packages/constructs/graphql-mesh-server/assets/handlers/maintenance/whitelist.test.ts
@@ -1,9 +1,15 @@
 // handler.test.ts
-import { cwd } from "process";
 import { handler } from "./whitelist";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { setWhitelist } from "./lib/file";
-import { existsSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Each suite owns an isolated directory so parallel suites can't race on a
+// shared maintenance file (see lib/file.ts MAINTENANCE_FILE_PATH).
+const maintenanceDir = mkdtempSync(join(tmpdir(), "maint-whitelist-"));
+process.env.MAINTENANCE_FILE_PATH = maintenanceDir;
 
 const createMockEvent = (
   method: string,
@@ -43,11 +49,11 @@ const mockAllowlist = [
 describe("Lambda handler", () => {
   beforeEach(() => {
     // Clean up any existing maintenance files before each test
-    if (existsSync(`${cwd()}/maintenance.enabled`)) {
-      rmSync(`${cwd()}/maintenance.enabled`);
+    if (existsSync(`${maintenanceDir}/maintenance.enabled`)) {
+      rmSync(`${maintenanceDir}/maintenance.enabled`);
     }
-    if (existsSync(`${cwd()}/maintenance.disabled`)) {
-      rmSync(`${cwd()}/maintenance.disabled`);
+    if (existsSync(`${maintenanceDir}/maintenance.disabled`)) {
+      rmSync(`${maintenanceDir}/maintenance.disabled`);
     }
     // Reset the whitelist before each test to ensure test isolation
     setWhitelist(mockAllowlist);
@@ -101,12 +107,6 @@ describe("Lambda handler", () => {
   });
 
   afterAll(() => {
-    if (existsSync(`${cwd()}/maintenance.enabled`)) {
-      rmSync(`${cwd()}/maintenance.enabled`);
-    }
-
-    if (existsSync(`${cwd()}/maintenance.disabled`)) {
-      rmSync(`${cwd()}/maintenance.disabled`);
-    }
+    rmSync(maintenanceDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Problem

`graphql-mesh-server`'s maintenance handler tests are flaky. They surfaced in the [release workflow run #26996333785](https://github.com/aligent/cdk-constructs/actions/runs/26996333785/job/79666741299), where `whitelist.test.ts › should handle GET method` returned `{ whitelist: [] }` instead of the seeded allowlist. A re-run of that same workflow now passes — confirming it was non-deterministic, not a real regression.

## Root cause

`jest.mock-env.ts` sets `MAINTENANCE_FILE_PATH = cwd()` for every suite, and `lib/file.ts` reads/writes `${MAINTENANCE_FILE_PATH}/maintenance.{enabled,disabled}`. So `whitelist.test.ts` and `maintenance.test.ts` operate on **one shared file**. Jest runs test files in parallel workers, so their `beforeEach` blocks (each `rmSync` + rewrite the file) race across processes:

1. `whitelist` writes the file with the seeded allowlist
2. `maintenance` (other worker) removes it and recreates it as `{ whitelist: [], sites: ... }`
3. `whitelist`'s GET reads the file → empty → assertion fails

A torn read (one worker reading mid-write by the other) is a second signature of the same race.

## Fix

- `lib/file.ts` now resolves `MAINTENANCE_FILE_PATH` **lazily** (`getPaths()`) instead of freezing it into module-level `const`s at import time, so each suite can point it at its own directory. It also throws a clear error if the path is unset rather than silently writing to `undefined/maintenance.*`.
- `whitelist.test.ts` and `maintenance.test.ts` each create a unique `mkdtempSync` directory and set `MAINTENANCE_FILE_PATH` to it; `afterAll` removes it. No shared state between suites.
- New `lib/file.test.ts` locks in lazy resolution + directory isolation as a regression guard.

## Verification

- Package suite run 8× consecutively: 8/8 green (was ~1-in-5 failing before).
- `nx lint graphql-mesh-server`: clean.

Includes a patch changeset for `@aligent/cdk-graphql-mesh-server`.