### PR TITLE
Fix conflicting throughput config when aspect overrides DynamoDB billing mode

### DIFF
--- a/.changeset/fix-dynamodb-billing-mode-conflict.md
+++ b/.changeset/fix-dynamodb-billing-mode-conflict.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-aspects": patch
+---
+
+Fix conflicting throughput config when aspect overrides DynamoDB billing mode

--- a/packages/cdk-aspects/lib/defaults/dynamodb.test.ts
+++ b/packages/cdk-aspects/lib/defaults/dynamodb.test.ts
@@ -60,7 +60,7 @@ describe("DynamoDbDefaultsAspect", () => {
       });
     });
 
-    it("does not override an existing ProvisionedThroughput", () => {
+    it("overrides existing ProvisionedThroughput with aspect defaults", () => {
       const table = makeTable(stack, "MyTable");
       const cfnTable = table.node.defaultChild as CfnTable;
       cfnTable.provisionedThroughput = {
@@ -71,10 +71,26 @@ describe("DynamoDbDefaultsAspect", () => {
 
       Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
         ProvisionedThroughput: {
-          ReadCapacityUnits: 10,
-          WriteCapacityUnits: 10,
+          ReadCapacityUnits: 1,
+          WriteCapacityUnits: 1,
         },
       });
+    });
+
+    it("clears OnDemandThroughput when setting PROVISIONED billing mode", () => {
+      const table = makeTable(stack, "MyTable");
+      const cfnTable = table.node.defaultChild as CfnTable;
+      cfnTable.onDemandThroughput = {
+        maxReadRequestUnits: 50,
+        maxWriteRequestUnits: 50,
+      };
+      app.synth();
+
+      const resources = Template.fromStack(stack).findResources(
+        "AWS::DynamoDB::Table"
+      );
+      const props = Object.values(resources)[0].Properties;
+      expect(props["OnDemandThroughput"]).toBeUndefined();
     });
 
     it("applies DESTROY removal policy", () => {
@@ -127,7 +143,7 @@ describe("DynamoDbDefaultsAspect", () => {
       expect(props["OnDemandThroughput"]).toBeUndefined();
     });
 
-    it("does not override an existing OnDemandThroughput", () => {
+    it("overrides existing OnDemandThroughput with aspect defaults", () => {
       const table = makeTable(stack, "MyTable");
       const cfnTable = table.node.defaultChild as CfnTable;
       cfnTable.onDemandThroughput = {
@@ -138,10 +154,21 @@ describe("DynamoDbDefaultsAspect", () => {
 
       Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
         OnDemandThroughput: {
-          MaxReadRequestUnits: 50,
-          MaxWriteRequestUnits: 50,
+          MaxReadRequestUnits: 100,
+          MaxWriteRequestUnits: 100,
         },
       });
+    });
+
+    it("clears ProvisionedThroughput set by CDK L2 defaults", () => {
+      makeTable(stack, "MyTable");
+      app.synth();
+
+      const resources = Template.fromStack(stack).findResources(
+        "AWS::DynamoDB::Table"
+      );
+      const props = Object.values(resources)[0].Properties;
+      expect(props["ProvisionedThroughput"]).toBeUndefined();
     });
 
     it("applies DESTROY removal policy", () => {
@@ -165,6 +192,17 @@ describe("DynamoDbDefaultsAspect", () => {
       Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
         BillingMode: "PAY_PER_REQUEST",
       });
+    });
+
+    it("clears ProvisionedThroughput set by CDK L2 defaults", () => {
+      makeTable(stack, "MyTable");
+      app.synth();
+
+      const resources = Template.fromStack(stack).findResources(
+        "AWS::DynamoDB::Table"
+      );
+      const props = Object.values(resources)[0].Properties;
+      expect(props["ProvisionedThroughput"]).toBeUndefined();
     });
 
     it("does not set on-demand throughput limits (no cap for LONG)", () => {

--- a/packages/cdk-aspects/lib/defaults/dynamodb.ts
+++ b/packages/cdk-aspects/lib/defaults/dynamodb.ts
@@ -31,8 +31,10 @@ interface Config {
  *
  * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_dynamodb.Table.html
  */
+type DefaultProps = TableProps & { billingMode: BillingMode };
+
 export class DynamoDbDefaultsAspect implements IAspect {
-  private readonly defaultProps: TableProps;
+  private readonly defaultProps: DefaultProps;
 
   /**
    * Creates a new DynamoDbDefaultsAspect
@@ -51,7 +53,7 @@ export class DynamoDbDefaultsAspect implements IAspect {
    */
   private retentionProperties(
     duration: "SHORT" | "MEDIUM" | "LONG"
-  ): TableProps {
+  ): DefaultProps {
     switch (duration) {
       case "SHORT":
         return {
@@ -122,29 +124,32 @@ export class DynamoDbDefaultsAspect implements IAspect {
       const cfnTable = node.node.defaultChild as CfnTable;
       if (!cfnTable) return;
 
-      if (cfnTable.billingMode === undefined) {
-        cfnTable.billingMode = billingMode;
+      cfnTable.billingMode = cfnTable.billingMode ?? billingMode;
+
+      // Clear conflicting throughput config to prevent CloudFormation errors
+      if (cfnTable.billingMode === BillingMode.PAY_PER_REQUEST) {
+        cfnTable.provisionedThroughput = undefined;
+      } else if (cfnTable.billingMode === BillingMode.PROVISIONED) {
+        cfnTable.onDemandThroughput = undefined;
       }
 
       if (
-        cfnTable.provisionedThroughput === undefined &&
-        cfnTable.billingMode !== BillingMode.PAY_PER_REQUEST &&
-        this.isProvisionedThroughputConfigured()
-      ) {
-        cfnTable.provisionedThroughput = {
-          readCapacityUnits: readCapacity!,
-          writeCapacityUnits: writeCapacity!,
-        };
-      }
-
-      if (
-        cfnTable.onDemandThroughput === undefined &&
-        cfnTable.billingMode !== BillingMode.PROVISIONED &&
+        cfnTable.billingMode === BillingMode.PAY_PER_REQUEST &&
         this.isOnDemandThroughputConfigured()
       ) {
         cfnTable.onDemandThroughput = {
           maxReadRequestUnits,
           maxWriteRequestUnits,
+        };
+      }
+
+      if (
+        cfnTable.billingMode === BillingMode.PROVISIONED &&
+        this.isProvisionedThroughputConfigured()
+      ) {
+        cfnTable.provisionedThroughput = {
+          readCapacityUnits: readCapacity!,
+          writeCapacityUnits: writeCapacity!,
         };
       }
     }


### PR DESCRIPTION
**Description of the proposed changes**

- Fix `DynamoDbDefaultsAspect` to clear conflicting throughput configuration when overriding a table's billing mode, preventing CloudFormation deployment errors (e.g. when a table is created with `PROVISIONED` but the aspect switches it to `PAY_PER_REQUEST`, stale `ProvisionedThroughput` was left behind)
- Always apply aspect-default throughput values based on the resolved billing mode, replacing any pre-existing throughput config rather than skipping when one is already set

**Other solutions considered**

- Only clearing conflicting config without overriding existing throughput values — rejected because the aspect should enforce consistent defaults across all tables

**Notes to reviewers**

- 🛈 Toggl Code: _MI-326: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback