### PR TITLE
feat: support nested routes and configurable stage in SecureRestApi

### DIFF
--- a/.changeset/secure-rest-api-nested-routes.md
+++ b/.changeset/secure-rest-api-nested-routes.md
@@ -1,0 +1,7 @@
+---
+"@aligent/cdk-secure-rest-api": minor
+---
+
+Support nested (multi-segment) route paths in the `routes` helper. Paths such as `rewards/accounts/{accountId}/redeem` now create the intermediate resources instead of throwing `ResourceSPathPartOnly` at synth time. Routes sharing a common prefix resolve idempotently.
+
+Add a `deployOptions` prop (CDK `StageOptions`) so the deployed stage name and other stage settings can be configured. Defaults to the CDK `prod` stage when omitted.

--- a/packages/constructs/secure-rest-api/README.md
+++ b/packages/constructs/secure-rest-api/README.md
@@ -12,6 +12,8 @@ A CDK construct for provisioning an API Gateway REST API secured with API Key au
 - Usage plan with configurable throttle rate and burst limits
 - Configurable CORS preflight options
 - Accepts any CDK `Integration` per route (Lambda, HTTP, Mock, Step Functions, etc.)
+- Supports nested, multi-segment route paths (e.g. `rewards/accounts/{accountId}/redeem`)
+- Configurable deployment stage via `deployOptions` (stage name defaults to `prod`)
 
 ## Installation
 
@@ -74,6 +76,29 @@ const api = new SecureRestApi(this, 'Api', {
 });
 ```
 
+### Nested route paths
+
+Multi-segment paths create the intermediate resources automatically. Routes
+sharing a common prefix resolve to the same parent resource.
+
+```typescript
+const api = new SecureRestApi(this, 'Api', {
+  apiName: 'rewards-api',
+  routes: [
+    {
+      path: 'rewards/accounts/{accountId}/redeem',
+      methods: [HttpMethod.POST],
+      integration: new LambdaIntegration(redeemFunction),
+    },
+    {
+      path: 'rewards/reversal', // reuses the shared `rewards` resource
+      methods: [HttpMethod.POST],
+      integration: new LambdaIntegration(reversalFunction),
+    },
+  ],
+});
+```
+
 ### Custom throttling
 
 ```typescript
@@ -83,6 +108,19 @@ const api = new SecureRestApi(this, 'Api', {
     rateLimit: 50,   // requests per second
     burstLimit: 100,
   },
+  routes: [...],
+});
+```
+
+### Custom stage name
+
+By default the API deploys to a `prod` stage. Pass `deployOptions` to override
+the stage name (or any other CDK `StageOptions`, e.g. logging or tracing).
+
+```typescript
+const api = new SecureRestApi(this, 'Api', {
+  apiName: 'my-api',
+  deployOptions: { stageName: 'staging' },
   routes: [...],
 });
 ```
@@ -119,9 +157,16 @@ Routes to register on the API. Each route requires:
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `path` | `string` | The resource path (leading slash is stripped automatically) |
+| `path` | `string` | The resource path; may be nested/multi-segment (leading slash is stripped automatically) |
 | `methods` | `HttpMethod[]` | HTTP methods to register on the resource |
 | `integration` | `Integration` | Any CDK API Gateway integration |
+
+### `deployOptions` (StageOptions)
+
+Stage options for the API's default deployment, passed through to the underlying
+CDK `RestApi`. Use `stageName` to override the deployed stage name.
+
+Default: CDK default (`prod` stage).
 
 ### `throttle` (object)
 

--- a/packages/constructs/secure-rest-api/lib/secure-rest-api.test.ts
+++ b/packages/constructs/secure-rest-api/lib/secure-rest-api.test.ts
@@ -91,6 +91,88 @@ describe("SecureRestApi", () => {
       });
     });
 
+    it("registers a nested multi-segment route", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        routes: [
+          {
+            path: "rewards/accounts/{accountId}/redeem",
+            methods: [HttpMethod.POST],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::Method",
+        {
+          HttpMethod: "POST",
+          ApiKeyRequired: true,
+        }
+      );
+    });
+
+    it("creates intermediate resources for a nested route", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        routes: [
+          {
+            path: "rewards/accounts/{accountId}/redeem",
+            methods: [HttpMethod.POST],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      const template = Template.fromStack(stack);
+      for (const pathPart of ["rewards", "accounts", "{accountId}", "redeem"]) {
+        template.hasResourceProperties("AWS::ApiGateway::Resource", {
+          PathPart: pathPart,
+        });
+      }
+    });
+
+    it("resolves routes sharing a prefix without duplicate resources", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        routes: [
+          {
+            path: "rewards/accounts/{accountId}/redeem",
+            methods: [HttpMethod.POST],
+            integration: mockIntegration(),
+          },
+          {
+            path: "rewards/reversal",
+            methods: [HttpMethod.POST],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      const template = Template.fromStack(stack);
+      const resourcesByPathPart = (pathPart: string) =>
+        Object.values(
+          template.findResources("AWS::ApiGateway::Resource")
+        ).filter(r => r.Properties?.PathPart === pathPart);
+
+      // The shared "rewards" parent is created exactly once.
+      expect(resourcesByPathPart("rewards")).toHaveLength(1);
+
+      // Both leaf resources exist under the shared parent.
+      expect(resourcesByPathPart("redeem")).toHaveLength(1);
+      expect(resourcesByPathPart("reversal")).toHaveLength(1);
+
+      // Each leaf registers its POST method with apiKeyRequired.
+      template.resourcePropertiesCountIs(
+        "AWS::ApiGateway::Method",
+        { HttpMethod: "POST", ApiKeyRequired: true },
+        2
+      );
+    });
+
     it("accepts a LambdaIntegration as route integration", () => {
       const { stack } = createStack();
       new SecureRestApi(stack, "Api", {
@@ -105,6 +187,51 @@ describe("SecureRestApi", () => {
       });
 
       Template.fromStack(stack).resourceCountIs("AWS::Lambda::Function", 1);
+    });
+  });
+
+  describe("Deployment stage", () => {
+    it("uses a custom stage name from deployOptions", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        deployOptions: { stageName: "staging" },
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::Stage",
+        {
+          StageName: "staging",
+        }
+      );
+    });
+
+    it("defaults the stage name to prod", () => {
+      const { stack } = createStack();
+      new SecureRestApi(stack, "Api", {
+        apiName: "my-api",
+        routes: [
+          {
+            path: "items",
+            methods: [HttpMethod.GET],
+            integration: mockIntegration(),
+          },
+        ],
+      });
+
+      Template.fromStack(stack).hasResourceProperties(
+        "AWS::ApiGateway::Stage",
+        {
+          StageName: "prod",
+        }
+      );
     });
   });
 

--- a/packages/constructs/secure-rest-api/lib/secure-rest-api.ts
+++ b/packages/constructs/secure-rest-api/lib/secure-rest-api.ts
@@ -4,6 +4,7 @@ import {
   Integration,
   IRestApi,
   RestApi,
+  StageOptions,
   UsagePlan,
 } from "aws-cdk-lib/aws-apigateway";
 import { HttpMethod } from "aws-cdk-lib/aws-apigatewayv2";
@@ -45,6 +46,14 @@ export interface SecureRestApiProps {
   routes: SecureRestApiRoute[];
 
   /**
+   * Stage options for the API's default deployment.
+   *
+   * Use `stageName` to override the deployed stage name.
+   * @default stageName "prod" (CDK default)
+   */
+  deployOptions?: StageOptions;
+
+  /**
    * Throttling limits for the usage plan.
    * @default { rateLimit: 100, burstLimit: 200 }
    */
@@ -79,6 +88,7 @@ export class SecureRestApi extends Construct {
       description,
       corsOptions,
       routes,
+      deployOptions,
       throttle = { rateLimit: 100, burstLimit: 200 },
       apiKeyName,
       usagePlanName,
@@ -87,6 +97,7 @@ export class SecureRestApi extends Construct {
     this.api = new RestApi(this, "Api", {
       restApiName: apiName,
       description: description ?? `REST API for ${apiName} service`,
+      deployOptions,
       defaultCorsPreflightOptions: {
         allowOrigins: corsOptions?.allowOrigins ?? Cors.ALL_ORIGINS,
         allowMethods: [
@@ -103,7 +114,9 @@ export class SecureRestApi extends Construct {
     });
 
     for (const route of routes) {
-      const resource = this.api.root.addResource(route.path.replace(/^\//, ""));
+      const resource = this.api.root.resourceForPath(
+        route.path.replace(/^\//, "")
+      );
       for (const method of route.methods) {
         resource.addMethod(method, route.integration, { apiKeyRequired: true });
       }


### PR DESCRIPTION
## Summary

Two changes to `@aligent/cdk-secure-rest-api` (released together as a `minor`):

### Nested route paths
The `routes` helper only worked for single-segment paths. Any path with more than one segment (e.g. `rewards/accounts/{accountId}/redeem`) threw `ResourceSPathPartOnly` at synth time, because the construct passed the entire path to `IResource.addResource`, which only accepts a single path *part*. Swapped to `IResource.resourceForPath`, which splits on `/`, creates intermediate resources, and is idempotent for shared prefixes. The leading-slash strip is preserved for backwards compatibility.

### Configurable deployment stage (requested by Kai)
The stage name was always `prod` (CDK's default). Added a `deployOptions?: StageOptions` prop passed straight through to the underlying `RestApi`, so callers can set `stageName` (and any other stage settings — logging, tracing, etc.). Defaults to the CDK `prod` stage when omitted.

```ts
new SecureRestApi(this, 'Api', {
  apiName: 'my-api',
  deployOptions: { stageName: 'staging' },
  routes: [...],
});
```

## Changes

- `lib/secure-rest-api.ts` — `resourceForPath`; new `deployOptions` prop
- Tests (17 total): nested route method registration, intermediate resource creation, shared-prefix resolution (shared parent created once + both leaf methods registered), custom stage name, default `prod` stage
- README — nested-path + stage-name features, examples, reference entries
- Changeset (`minor`)

## Testing

- `yarn nx test secure-rest-api` — 17/17 pass
- `yarn nx lint secure-rest-api` — clean