### PR TITLE
feat(cdk-aspects): add API Gateway stage name validation and S3 auto-delete

### DIFF
--- a/.changeset/soft-boats-make.md
+++ b/.changeset/soft-boats-make.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-aspects": minor
+---
+
+Add API Gateway stage name validation rule to MicroserviceChecks and enable autoDeleteObjects for SHORT/MEDIUM S3 bucket retention profiles.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/aligent/aws-cdk-constructs#readme",
   "scripts": {
+    "audit": "nx run-many -t lint typecheck test --configuration coverage --skip-nx-cache",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:version-and-install": "changeset version && yarn install --no-immutable",

--- a/packages/cdk-aspects/README.md
+++ b/packages/cdk-aspects/README.md
@@ -92,6 +92,7 @@ A set of rules that validate your infrastructure against recommended practices u
 - Validates Lambda function timeout configuration
 - Validates Lambda function tracing configuration
 - Validates CloudWatch Log Group retention policy
+- Validates API Gateway stage name matches the expected value (must be exactly 3 lowercase alphanumeric characters, e.g. `dev`, `stg`, `prd`)
 
 ### Usage
 
@@ -102,7 +103,7 @@ import { MicroserviceChecks } from "@aligent/cdk-aspects";
 const app = new App();
 const stack = new Stack(app, "MyStack");
 
-Aspects.of(stack).add(new MicroserviceChecks());
+Aspects.of(stack).add(new MicroserviceChecks({ stageName: "prd" }));
 ```
 
 ## Resource Prefix

--- a/packages/cdk-aspects/lib/defaults/s3-bucket.ts
+++ b/packages/cdk-aspects/lib/defaults/s3-bucket.ts
@@ -2,26 +2,35 @@ import { Duration, RemovalPolicy, type IAspect } from "aws-cdk-lib";
 import { Bucket, CfnBucket, type BucketProps } from "aws-cdk-lib/aws-s3";
 import { IConstruct } from "constructs";
 
+/**
+ * Configuration for the {@link S3DefaultsAspect}.
+ *
+ * @property duration - Controls the retention behaviour applied to S3 buckets:
+ *   - `SHORT`  — 30-day object expiration, auto-delete on stack removal.
+ *   - `MEDIUM` — 90-day object expiration, auto-delete on stack removal.
+ *   - `LONG`   — No expiration, bucket is retained on stack removal.
+ */
 interface Config {
   duration: "SHORT" | "MEDIUM" | "LONG";
 }
 
 /**
- * Aspect that automatically applies configuration-aware defaults to S3 Buckets
+ * CDK Aspect that applies duration-based lifecycle and removal policies to S3 Buckets.
  *
- * Visits all constructs in the scope and automatically applies configuration-specific
- * lifecycle and removal policies to S3 buckets. Different configurations balance
- * between cost optimization and data retention needs.
+ * When added to a scope, this aspect visits every {@link Bucket} construct and:
+ * 1. Sets the removal policy (`DESTROY` for SHORT/MEDIUM, `RETAIN` for LONG).
+ * 2. Adds lifecycle rules with an object expiration (30 or 90 days) — only if the
+ *    bucket does not already have an explicit lifecycle configuration.
  *
  * @example
  * ```typescript
- * // Apply configuration-specific defaults to all buckets
- * Aspects.of(app).add(new S3DefaultsAspect({ autoDelete: true, duration: 'SHORT' }));
+ * import { Aspects } from 'aws-cdk-lib';
  *
- * // Buckets automatically inherit configuration defaults
- * new Bucket(stack, 'MyBucket', {
- *   // lifecycle and removal policy applied automatically
- * });
+ * // Short-lived buckets: objects expire after 30 days, bucket deleted with stack
+ * Aspects.of(stack).add(new S3DefaultsAspect({ duration: 'SHORT' }));
+ *
+ * // Long-lived buckets: no expiration, bucket retained on stack removal
+ * Aspects.of(stack).add(new S3DefaultsAspect({ duration: 'LONG' }));
  * ```
  *
  * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.Bucket.html
@@ -30,9 +39,9 @@ export class S3DefaultsAspect implements IAspect {
   private readonly defaultProps: BucketProps;
 
   /**
-   * Creates a new S3DefaultsAspect
+   * Creates a new S3DefaultsAspect.
    *
-   * @param config - Configuration identifier used to select appropriate defaults.
+   * @param config - Determines which retention profile to apply to buckets in scope.
    */
   constructor(config: Config) {
     const props = this.retentionProperties(config.duration);
@@ -40,10 +49,11 @@ export class S3DefaultsAspect implements IAspect {
   }
 
   /**
-   * Get duration-specific object expiration
+   * Returns duration-specific bucket properties (lifecycle rules, removal policy,
+   * and auto-delete flag).
    *
-   * @param duration - The duration to get the expiration for
-   * @returns The expiration Duration, or undefined for LONG retention
+   * @param duration - The retention profile to resolve.
+   * @returns Partial {@link BucketProps} appropriate for the given duration.
    */
   private retentionProperties(duration: "SHORT" | "MEDIUM" | "LONG") {
     switch (duration) {
@@ -51,11 +61,13 @@ export class S3DefaultsAspect implements IAspect {
         return {
           lifecycleRules: [{ expiration: Duration.days(30) }],
           removalPolicy: RemovalPolicy.DESTROY,
+          autoDeleteObjects: true,
         };
       case "MEDIUM":
         return {
           lifecycleRules: [{ expiration: Duration.days(90) }],
           removalPolicy: RemovalPolicy.DESTROY,
+          autoDeleteObjects: true,
         };
       default:
         return {
@@ -66,12 +78,13 @@ export class S3DefaultsAspect implements IAspect {
   }
 
   /**
-   * Visits a construct and applies configuration-appropriate defaults
+   * Visits a construct and, if it is an S3 {@link Bucket}, applies the
+   * configured removal policy and lifecycle rules.
    *
-   * Applies a removal policy and lifecycle rules to buckets that don't
-   * already have a lifecycle configuration explicitly set.
+   * Lifecycle rules are only added when the bucket's underlying
+   * {@link CfnBucket} does not already have a `lifecycleConfiguration`.
    *
-   * @param node - The construct to potentially modify
+   * @param node - The construct being visited by the CDK aspect traversal.
    */
   visit(node: IConstruct): void {
     if (node instanceof Bucket) {

--- a/packages/cdk-aspects/lib/defaults/s3-bucket.ts
+++ b/packages/cdk-aspects/lib/defaults/s3-bucket.ts
@@ -2,6 +2,11 @@ import { Duration, RemovalPolicy, type IAspect } from "aws-cdk-lib";
 import { Bucket, CfnBucket, type BucketProps } from "aws-cdk-lib/aws-s3";
 import { IConstruct } from "constructs";
 
+/** Exposes the private {@link Bucket.enableAutoDeleteObjects} method. */
+interface BucketWithAutoDelete {
+  enableAutoDeleteObjects(): void;
+}
+
 /**
  * Configuration for the {@link S3DefaultsAspect}.
  *
@@ -79,7 +84,10 @@ export class S3DefaultsAspect implements IAspect {
 
   /**
    * Visits a construct and, if it is an S3 {@link Bucket}, applies the
-   * configured removal policy and lifecycle rules.
+   * configured removal policy, auto-delete behaviour, and lifecycle rules.
+   *
+   * When `autoDeleteObjects` is enabled, we call the private `enableAutoDeleteObjects` which
+   * provisions a Lambda-backed custom resource is to empty the bucket before CloudFormation deletes it.
    *
    * Lifecycle rules are only added when the bucket's underlying
    * {@link CfnBucket} does not already have a `lifecycleConfiguration`.
@@ -88,9 +96,16 @@ export class S3DefaultsAspect implements IAspect {
    */
   visit(node: IConstruct): void {
     if (node instanceof Bucket) {
-      const { lifecycleRules, removalPolicy } = this.defaultProps;
+      const { lifecycleRules, removalPolicy, autoDeleteObjects } =
+        this.defaultProps;
       if (removalPolicy) {
         node.applyRemovalPolicy(removalPolicy);
+      }
+
+      if (autoDeleteObjects) {
+        // NOTE: This relies on a private CDK API and may break in future aws-cdk-lib releases.
+        // @see https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-s3/lib/bucket.ts#L3357
+        (node as unknown as BucketWithAutoDelete).enableAutoDeleteObjects();
       }
 
       if (lifecycleRules?.length) {

--- a/packages/cdk-aspects/lib/microservice-checks.test.ts
+++ b/packages/cdk-aspects/lib/microservice-checks.test.ts
@@ -1,5 +1,6 @@
 import { App, Aspects, Stack } from "aws-cdk-lib";
 import { Annotations, Match } from "aws-cdk-lib/assertions";
+import { RestApi } from "aws-cdk-lib/aws-apigateway";
 import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
 import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import { Bucket } from "aws-cdk-lib/aws-s3";
@@ -8,27 +9,54 @@ import { MicroserviceChecks } from "./microservice-checks";
 
 describe("MicroserviceChecks", () => {
   it("should have the correct pack name", () => {
-    const checks = new MicroserviceChecks();
+    const checks = new MicroserviceChecks({ stageName: "dev" });
 
     expect(checks.readPackName).toBe("Microservices");
   });
 
   it("should instantiate with props", () => {
-    const checks = new MicroserviceChecks({ verbose: true });
-
-    expect(checks).toBeInstanceOf(MicroserviceChecks);
-  });
-
-  it("should instantiate without props", () => {
-    const checks = new MicroserviceChecks();
+    const checks = new MicroserviceChecks({ stageName: "dev", verbose: true });
 
     expect(checks).toBeInstanceOf(MicroserviceChecks);
   });
 
   it("should have a visit method", () => {
-    const checks = new MicroserviceChecks();
+    const checks = new MicroserviceChecks({ stageName: "dev" });
 
     expect(typeof checks.visit).toBe("function");
+  });
+
+  describe("stageName validation", () => {
+    it("should accept a valid 3-char lowercase alphanumeric stageName", () => {
+      expect(() => new MicroserviceChecks({ stageName: "dev" })).not.toThrow();
+      expect(() => new MicroserviceChecks({ stageName: "stg" })).not.toThrow();
+      expect(() => new MicroserviceChecks({ stageName: "prd" })).not.toThrow();
+      expect(() => new MicroserviceChecks({ stageName: "ab1" })).not.toThrow();
+    });
+
+    it("should throw for a stageName that is too short", () => {
+      expect(() => new MicroserviceChecks({ stageName: "de" })).toThrow(
+        "stageName must be exactly 3 lowercase alphanumeric characters"
+      );
+    });
+
+    it("should throw for a stageName that is too long", () => {
+      expect(() => new MicroserviceChecks({ stageName: "devv" })).toThrow(
+        "stageName must be exactly 3 lowercase alphanumeric characters"
+      );
+    });
+
+    it("should throw for a stageName with uppercase characters", () => {
+      expect(() => new MicroserviceChecks({ stageName: "DEV" })).toThrow(
+        "stageName must be exactly 3 lowercase alphanumeric characters"
+      );
+    });
+
+    it("should throw for a stageName with special characters", () => {
+      expect(() => new MicroserviceChecks({ stageName: "d-v" })).toThrow(
+        "stageName must be exactly 3 lowercase alphanumeric characters"
+      );
+    });
   });
 
   describe("visit", () => {
@@ -41,7 +69,7 @@ describe("MicroserviceChecks", () => {
         },
       });
       const stack = new Stack(app, "TestStack");
-      const checks = new MicroserviceChecks();
+      const checks = new MicroserviceChecks({ stageName: "dev" });
       Aspects.of(stack).add(checks);
 
       new Function(stack, "TestFunction", {
@@ -94,6 +122,42 @@ describe("MicroserviceChecks", () => {
     });
   });
 
+  describe("API Gateway stage name rule", () => {
+    it("should trigger an error when stageName does not match", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      Aspects.of(stack).add(new MicroserviceChecks({ stageName: "prd" }));
+
+      const api = new RestApi(stack, "TestApi", {
+        deployOptions: { stageName: "dev" },
+      });
+      api.root.addMethod("GET");
+
+      const annotations = Annotations.fromStack(stack);
+      annotations.hasError(
+        "/TestStack/TestApi/DeploymentStage.dev/Resource",
+        Match.stringLikeRegexp("does not have a valid stageName configured")
+      );
+    });
+
+    it("should not trigger an error when stageName matches", () => {
+      const app = new App();
+      const stack = new Stack(app, "TestStack");
+      Aspects.of(stack).add(new MicroserviceChecks({ stageName: "prd" }));
+
+      const api = new RestApi(stack, "TestApi", {
+        deployOptions: { stageName: "prd" },
+      });
+      api.root.addMethod("GET");
+
+      const annotations = Annotations.fromStack(stack);
+      annotations.hasNoError(
+        "/TestStack/TestApi/DeploymentStage.prd/Resource",
+        Match.stringLikeRegexp("does not have a valid stageName configured")
+      );
+    });
+  });
+
   describe("CDK-managed singletons", () => {
     let annotations: Annotations;
     let bucketDeploymentPath: string;
@@ -105,7 +169,7 @@ describe("MicroserviceChecks", () => {
         },
       });
       const stack = new Stack(app, "TestStack");
-      Aspects.of(stack).add(new MicroserviceChecks());
+      Aspects.of(stack).add(new MicroserviceChecks({ stageName: "dev" }));
 
       const bucket = new Bucket(stack, "DeployBucket");
       new BucketDeployment(stack, "DeployAssets", {

--- a/packages/cdk-aspects/lib/microservice-checks.ts
+++ b/packages/cdk-aspects/lib/microservice-checks.ts
@@ -1,7 +1,42 @@
 import { CfnResource } from "aws-cdk-lib";
-import { NagMessageLevel, NagPack, rules, type NagPackProps } from "cdk-nag";
+import { CfnStage } from "aws-cdk-lib/aws-apigateway";
+import {
+  NagMessageLevel,
+  NagPack,
+  NagRuleCompliance,
+  NagRuleResult,
+  NagRules,
+  rules,
+  type NagPackProps,
+} from "cdk-nag";
 import type { IConstruct } from "constructs";
 import { isCdkManagedSingleton } from "./cdk-managed-singletons";
+
+type RuleResult = (node: CfnResource) => NagRuleResult;
+
+/**
+ * Checks that an API Gateway stage name matches the expected value.
+ */
+function apiGatewayStageName(expected: string): RuleResult {
+  return (node: CfnResource) => {
+    if (node instanceof CfnStage) {
+      const stageName = NagRules.resolveIfPrimitive(node, node.stageName);
+      if (stageName !== expected) {
+        return NagRuleCompliance.NON_COMPLIANT;
+      }
+      return NagRuleCompliance.COMPLIANT;
+    }
+    return NagRuleCompliance.NOT_APPLICABLE;
+  };
+}
+
+export interface MicroserviceChecksProps extends NagPackProps {
+  /**
+   * The expected API Gateway stage name.
+   * Must be exactly 3 lowercase alphanumeric characters (e.g. dev, stg, prd).
+   */
+  readonly stageName: string;
+}
 
 /**
  * Microservice Checks are a compilation of rules to validate infrastructure-as-code template
@@ -12,12 +47,21 @@ import { isCdkManagedSingleton } from "./cdk-managed-singletons";
  * @example
  * const app = new App();
  * const stack = new Stack(app, 'MyStack');
- * Aspects.of(stack).add(new MicroservicesChecks());
+ * Aspects.of(stack).add(new MicroservicesChecks({ stageName: 'prd' }));
  */
 export class MicroserviceChecks extends NagPack {
-  constructor(props?: NagPackProps) {
+  private readonly stageName: string;
+
+  constructor(props: MicroserviceChecksProps) {
     super(props);
     this.packName = "Microservices";
+
+    if (!/^[a-z0-9]{3}$/.test(props.stageName)) {
+      throw new Error(
+        `stageName must be exactly 3 lowercase alphanumeric characters, got: "${props.stageName}"`
+      );
+    }
+    this.stageName = props.stageName;
   }
 
   public visit(node: IConstruct) {
@@ -54,6 +98,13 @@ export class MicroserviceChecks extends NagPack {
           "By default, logs are kept indefinitely and never expire. You can adjust the retention policy for each log group, keeping the indefinite retention, or choosing a retention period between one day and 10 years. For Lambda functions, this applies to their automatically created CloudWatch Log Groups.",
         level: NagMessageLevel.ERROR,
         rule: rules.cloudwatch.CloudWatchLogGroupRetentionPeriod,
+        node: node,
+      });
+      this.applyRule({
+        info: "The API Gateway stage does not have a valid stageName configured.",
+        explanation: `The API Gateway stage name must be exactly 3 lowercase alphanumeric characters and match the expected value "${this.stageName}". This ensures consistent naming conventions across environments (e.g. dev, stg, prd).`,
+        level: NagMessageLevel.ERROR,
+        rule: apiGatewayStageName(this.stageName),
         node: node,
       });
     }


### PR DESCRIPTION
**Description of the proposed changes**

- Add API Gateway stage name validation rule to `MicroserviceChecks` — stage name must be exactly 3 lowercase alphanumeric characters (e.g. `dev`, `stg`, `prd`) and match the expected value
- Enable `autoDeleteObjects: true` for SHORT and MEDIUM S3 bucket retention profiles in `S3DefaultsAspect`
- Improve JSDoc documentation for `S3DefaultsAspect`
- Add `audit` script to root `package.json`

**Notes to reviewers**

- 🛈 `MicroserviceChecks` now requires a `stageName` prop (breaking change to the constructor signature)
- 🛈 Toggl Code: _MI-331: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback