### PR TITLE
SMG-1300: Add recache delay to avoid a race condition

### DIFF
--- a/.changeset/empty-adults-clap.md
+++ b/.changeset/empty-adults-clap.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-prerender-fargate": minor
+---
+
+Add a configurable `recacheDelay` to `prerenderFargateRecachingOptions`. This controls the delay between purging the cached object from S3 and the recache consumer fetching the URL to re-render it, allowing frontend cache (e.g. CloudFront or Fastly) invalidations to propagate first and avoiding a race condition where stale upstream content is re-cached. Backed by the SQS message delay (max 15 minutes); defaults to 1 second, preserving existing behaviour.

--- a/packages/constructs/prerender-fargate/README.md
+++ b/packages/constructs/prerender-fargate/README.md
@@ -87,6 +87,8 @@ To use the PrerenderFargate construct, you can instantiate it with suitable Prer
 ### `prerenderFargateRecachingOptions` (PrerenderFargateRecachingOptions, optional)
 
 - This allows to alter the re-caching behaviour. The default configuration should be sufficient.
+- `maxConcurrentExecutions` (number, optional) - The maximum number of concurrent executions of the recache consumer. Default: 1
+- `recacheDelay` (Duration, optional) - The delay between purging the cached object from S3 and the recache consumer fetching the URL to re-render it. Use this to allow frontend cache (e.g. CloudFront) invalidations to propagate before the page is re-rendered, avoiding a race condition where stale upstream content is re-cached. Backed by the SQS message delay, so the maximum is 15 minutes. Default: `Duration.seconds(1)`
 
 ### `enableRecache` (boolean, optional)
 
@@ -105,7 +107,7 @@ To use the PrerenderFargate construct, you can instantiate it with suitable Prer
 Here's an example of how to use the PrerenderFargate construct in a TypeScript CDK application:
 
 ```typescript
-import { Stack, StackProps } from "aws-cdk-lib";
+import { Duration, Stack, StackProps } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import {
   PrerenderFargate,
@@ -134,6 +136,7 @@ export class RagPrerenderStackStack extends Stack {
       enableS3Endpoint: false,
       prerenderFargateRecachingOptions: {
         maxConcurrentExecutions: 1,
+        recacheDelay: Duration.seconds(30),
       },
       prerenderFargateScalingOptions: {
         healthCheckGracePeriod: 20,

--- a/packages/constructs/prerender-fargate/lib/prerender-fargate-options.ts
+++ b/packages/constructs/prerender-fargate/lib/prerender-fargate-options.ts
@@ -1,4 +1,5 @@
 import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { Duration } from "aws-cdk-lib";
 
 /**
  * Options for configuring the Prerender Fargate construct.
@@ -228,4 +229,16 @@ export interface PrerenderFargateRecachingOptions {
    * @default - 1
    */
   maxConcurrentExecutions?: number;
+  /**
+   * The delay between purging the cached object from S3 and the recache
+   * consumer fetching the URL to re-render it.
+   *
+   * Use this to allow frontend cache (e.g. CloudFront) invalidations to
+   * propagate before the page is re-rendered, avoiding a race condition
+   * where stale upstream content is re-cached.
+   *
+   * Backed by the SQS message delay, so the maximum is 15 minutes.
+   * @default - Duration.seconds(1)
+   */
+  recacheDelay?: Duration;
 }

--- a/packages/constructs/prerender-fargate/lib/prerender-fargate.ts
+++ b/packages/constructs/prerender-fargate/lib/prerender-fargate.ts
@@ -315,6 +315,7 @@ export class PrerenderFargate extends Construct {
           prerenderS3Bucket: this.bucket,
           maxConcurrentExecutions:
             prerenderFargateRecachingOptions?.maxConcurrentExecutions || 1,
+          recacheDelay: prerenderFargateRecachingOptions?.recacheDelay,
           tokenSecret,
           queueName,
           restApiName,

--- a/packages/constructs/prerender-fargate/lib/recaching/prerender-recache-api-construct.api.ts
+++ b/packages/constructs/prerender-fargate/lib/recaching/prerender-recache-api-construct.api.ts
@@ -36,6 +36,7 @@ interface PreRenderRequestBody {
 
 const QueueUrl = process.env.SQS_QUEUE_URL;
 const Bucket = process.env.PRERENDER_CACHE_BUCKET;
+const RecacheDelaySeconds = Number(process.env.RECACHE_DELAY_SECONDS ?? "1");
 
 export const MAX_URLS = 1000;
 
@@ -186,7 +187,7 @@ const deleteCacheContentForUrls = async (
 const queueRecachingUrls = async (urlsToRecache: string[]) => {
   const generateEntry = (url: string): SendMessageBatchRequestEntry => {
     return {
-      DelaySeconds: 1,
+      DelaySeconds: RecacheDelaySeconds,
       Id: md5hash(url) + url.replace(/[^A-Z0-9_-]+/gi, "_").slice(-47),
       MessageBody: url,
     };

--- a/packages/constructs/prerender-fargate/lib/recaching/prerender-recache-api-construct.ts
+++ b/packages/constructs/prerender-fargate/lib/recaching/prerender-recache-api-construct.ts
@@ -39,7 +39,21 @@ export interface PrerenderRecacheApiOptions {
    * @default - ID of the RestApi construct.
    */
   restApiName?: string;
+
+  /**
+   * The delay between purging the cached object from S3 and the recache
+   * consumer fetching the URL to re-render it. Backed by the SQS message
+   * delay, so the maximum is 15 minutes.
+   *
+   * @default - Duration.seconds(1)
+   */
+  recacheDelay?: Duration;
 }
+
+/**
+ * The maximum delay supported by SQS message delivery, in seconds.
+ */
+const MAX_RECACHE_DELAY_SECONDS = 900;
 
 /**
  * Represents an API for recaching prerendered pages.
@@ -139,6 +153,17 @@ const createApiLambdaFunction = (
   );
 
   apiHandler.addEnvironment("TOKEN_SECRET", options.tokenSecret);
+
+  const recacheDelaySeconds = options.recacheDelay?.toSeconds() ?? 1;
+  if (recacheDelaySeconds > MAX_RECACHE_DELAY_SECONDS) {
+    throw new Error(
+      `recacheDelay must not exceed ${MAX_RECACHE_DELAY_SECONDS} seconds (15 minutes), got ${recacheDelaySeconds}`
+    );
+  }
+  apiHandler.addEnvironment(
+    "RECACHE_DELAY_SECONDS",
+    recacheDelaySeconds.toString()
+  );
 
   return apiHandler;
 };


### PR DESCRIPTION
**Description of the proposed changes**
On some environments it can take ~300 seconds for the graphql cache to be properly purged and updated pricing to appear. Since we are recaching near instantly this means we occasionally end up re-caching the old price which causes issues with Google Merchant center. 

This PR adds a configurable delay so we can process the recache after that ~300 seconds and avoid recacing stale content. 

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

**Time Tracking**

ABC-xxx: code review, select project XXXX