### PR TITLE
feat: respect explicit DynamoDB throughput in DynamoDbDefaultsAspect

### DIFF
--- a/.changeset/respect-explicit-dynamodb-throughput.md
+++ b/.changeset/respect-explicit-dynamodb-throughput.md
@@ -1,0 +1,5 @@
+---
+"@aligent/cdk-aspects": minor
+---
+
+`DynamoDbDefaultsAspect` now treats profile throughput as a default rather than an override. Read/write throughput explicitly set on a `Table` construct is respected instead of being clobbered by the profile, so a high-throughput table can lift the MEDIUM on-demand cap (or set its own provisioned capacity) via normal construct props.

--- a/packages/cdk-aspects/README.md
+++ b/packages/cdk-aspects/README.md
@@ -81,6 +81,38 @@ const app = new App();
 Aspects.of(app).add(new StepFunctionsDefaultsAspect());
 ```
 
+### DynamoDB Defaults
+
+Automatically applies configuration-aware billing mode, throughput, and removal-policy defaults to DynamoDB tables.
+
+#### Features
+
+- Sets billing mode, throughput, and removal policy based on the duration profile
+- Duration profiles:
+  - **SHORT**: `PROVISIONED` (1 RCU / 1 WCU), destroy on stack deletion
+  - **MEDIUM**: `PAY_PER_REQUEST` capped at 100 max read / 100 max write request units, destroy on stack deletion
+  - **LONG**: `PAY_PER_REQUEST` uncapped, retain on stack deletion
+- Treats throughput as a **default, not an override**: values set on the `Table` construct are respected. To lift the MEDIUM cap on a high-throughput table, set the throughput explicitly on that table (billing mode included, so the value survives CDK's L2 defaults):
+
+  ```typescript
+  new Table(stack, "HighWriteTable", {
+    partitionKey: { name: "pk", type: AttributeType.STRING },
+    billingMode: BillingMode.PAY_PER_REQUEST,
+    maxReadRequestUnits: 4000,
+    maxWriteRequestUnits: 4000,
+  });
+  ```
+
+#### Usage
+
+```typescript
+import { Aspects } from "aws-cdk-lib";
+import { DynamoDbDefaultsAspect } from "@aligent/cdk-aspects";
+
+const app = new App();
+Aspects.of(app).add(new DynamoDbDefaultsAspect({ duration: "MEDIUM" }));
+```
+
 
 ## Microservice Checks
 

--- a/packages/cdk-aspects/lib/defaults/dynamodb.test.ts
+++ b/packages/cdk-aspects/lib/defaults/dynamodb.test.ts
@@ -60,19 +60,19 @@ describe("DynamoDbDefaultsAspect", () => {
       });
     });
 
-    it("overrides existing ProvisionedThroughput with aspect defaults", () => {
-      const table = makeTable(stack, "MyTable");
-      const cfnTable = table.node.defaultChild as CfnTable;
-      cfnTable.provisionedThroughput = {
-        readCapacityUnits: 10,
-        writeCapacityUnits: 10,
-      };
+    it("respects provisioned throughput explicitly set via construct props", () => {
+      new Table(stack, "HighCapacityTable", {
+        partitionKey: { name: "pk", type: AttributeType.STRING },
+        billingMode: BillingMode.PROVISIONED,
+        readCapacity: 25,
+        writeCapacity: 25,
+      });
       app.synth();
 
       Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
         ProvisionedThroughput: {
-          ReadCapacityUnits: 1,
-          WriteCapacityUnits: 1,
+          ReadCapacityUnits: 25,
+          WriteCapacityUnits: 25,
         },
       });
     });
@@ -143,19 +143,19 @@ describe("DynamoDbDefaultsAspect", () => {
       expect(props["OnDemandThroughput"]).toBeUndefined();
     });
 
-    it("overrides existing OnDemandThroughput with aspect defaults", () => {
-      const table = makeTable(stack, "MyTable");
-      const cfnTable = table.node.defaultChild as CfnTable;
-      cfnTable.onDemandThroughput = {
-        maxReadRequestUnits: 50,
-        maxWriteRequestUnits: 50,
-      };
+    it("respects on-demand throughput explicitly set via construct props", () => {
+      new Table(stack, "HighWriteTable", {
+        partitionKey: { name: "pk", type: AttributeType.STRING },
+        billingMode: BillingMode.PAY_PER_REQUEST,
+        maxReadRequestUnits: 4000,
+        maxWriteRequestUnits: 4000,
+      });
       app.synth();
 
       Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
         OnDemandThroughput: {
-          MaxReadRequestUnits: 100,
-          MaxWriteRequestUnits: 100,
+          MaxReadRequestUnits: 4000,
+          MaxWriteRequestUnits: 4000,
         },
       });
     });

--- a/packages/cdk-aspects/lib/defaults/dynamodb.ts
+++ b/packages/cdk-aspects/lib/defaults/dynamodb.ts
@@ -133,9 +133,14 @@ export class DynamoDbDefaultsAspect implements IAspect {
         cfnTable.onDemandThroughput = undefined;
       }
 
+      // Stamp throughput as a default, not an override: the first predicate asks
+      // "does this profile carry throughput numbers?" (aspect config); the
+      // `=== undefined` check asks "has the table not already set its own?" (per
+      // table). Together they let a consumer raise/clear a cap via construct props.
       if (
         cfnTable.billingMode === BillingMode.PAY_PER_REQUEST &&
-        this.isOnDemandThroughputConfigured()
+        this.isOnDemandThroughputConfigured() &&
+        cfnTable.onDemandThroughput === undefined
       ) {
         cfnTable.onDemandThroughput = {
           maxReadRequestUnits,
@@ -145,7 +150,8 @@ export class DynamoDbDefaultsAspect implements IAspect {
 
       if (
         cfnTable.billingMode === BillingMode.PROVISIONED &&
-        this.isProvisionedThroughputConfigured()
+        this.isProvisionedThroughputConfigured() &&
+        cfnTable.provisionedThroughput === undefined
       ) {
         cfnTable.provisionedThroughput = {
           readCapacityUnits: readCapacity!,


### PR DESCRIPTION
## Summary

`DynamoDbDefaultsAspect` treated its profile throughput as an **override** — it stamped `onDemandThroughput` / `provisionedThroughput` onto every table regardless of what the `Table` construct already declared. Under the `MEDIUM` profile this capped every on-demand table at 100/100 RRU/WRU with no per-table escape, throttling high-write tables (see the originating incident: a product-sync burst hitting `TableWriteMaxOnDemandThroughputExceeded`).

This change treats profile throughput as a **default, not an override**, mirroring how `billingMode` is already handled (`?? default`). A value explicitly set on the `Table` construct is respected; the profile only fills in tables that say nothing — so the staging cost cap stays intact for the default case.

## Changes

- `lib/defaults/dynamodb.ts` — only stamp throughput when the `CfnTable` hasn't already set it (`onDemandThroughput === undefined` / `provisionedThroughput === undefined`), applied symmetrically to both branches. Added a comment explaining the two-predicate condition.
- `lib/defaults/dynamodb.test.ts` — flipped the two "overrides existing" tests to "respects explicitly set" behaviour, exercised through the real L2 `Table` props path.
- `README.md` — added the (previously missing) DynamoDB Defaults section documenting the profiles and the respect-explicit behaviour.
- Changeset: **minor**.

## Consumer note

To lift the cap on a table, set the throughput **and** `billingMode: PAY_PER_REQUEST` on the `Table` — CDK's L2 discards the request-unit props when billing mode resolves to `PROVISIONED`, *before any aspect runs*. Documented in the README example.

## Downstream impact

Lets `gra-ap21` drop its `UncapOnDemandThroughputAspect` workaround and set throughput directly on the affected tables, then bump `@aligent/cdk-aspects`.

## Testing

- `yarn nx test cdk-aspects` — 67 passed
- `yarn nx lint cdk-aspects` — clean (2 pre-existing non-null-assertion warnings, untouched)
